### PR TITLE
Clickhouse fixes for cluster operation

### DIFF
--- a/flyway-database-clickhouse/pom.xml
+++ b/flyway-database-clickhouse/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.flywaydb</groupId>
         <artifactId>flyway-community-db-support</artifactId>
-        <version>10.7.0</version>
+        <version>10.7.1</version>
     </parent>
 
     <artifactId>flyway-database-clickhouse</artifactId>

--- a/flyway-database-clickhouse/src/main/java/org/flywaydb/community/database/clickhouse/ClickHouseConnection.java
+++ b/flyway-database-clickhouse/src/main/java/org/flywaydb/community/database/clickhouse/ClickHouseConnection.java
@@ -27,12 +27,15 @@ public class ClickHouseConnection extends Connection<ClickHouseDatabase> {
 
     @Override
     protected String getCurrentSchemaNameOrSearchPath() throws SQLException {
-        return Optional.ofNullable(getJdbcTemplate().getConnection().getSchema()).map(database::unQuote).orElse(null);
+        return Optional.ofNullable(getJdbcTemplate().getConnection().getCatalog()).map(database::unQuote).orElse(null);
     }
 
     @Override
     public void doChangeCurrentSchemaOrSearchPathTo(String schema) throws SQLException {
-        getJdbcTemplate().getConnection().setSchema(schema);
+        // databaseTerm is catalog since driver version 0.5.0
+        // https://github.com/ClickHouse/clickhouse-java/issues/1273 & https://github.com/dbeaver/dbeaver/issues/19383
+        // For compatibility with old libraries, ((ClickHouseConnection) getJdbcConnection()).useCatalog() should be checked
+        getJdbcTemplate().getConnection().setCatalog(schema);
     }
 
     @Override

--- a/flyway-database-clickhouse/src/main/java/org/flywaydb/community/database/clickhouse/ClickHouseSchema.java
+++ b/flyway-database-clickhouse/src/main/java/org/flywaydb/community/database/clickhouse/ClickHouseSchema.java
@@ -56,8 +56,8 @@ public class ClickHouseSchema extends Schema<ClickHouseDatabase, ClickHouseTable
 
     @Override
     protected void doDrop() throws SQLException {
-        if (jdbcTemplate.getConnection().getSchema().equals(name)) {
-            jdbcTemplate.getConnection().setSchema("default");
+        if (jdbcTemplate.getConnection().getCatalog().equals(name)) {
+            jdbcTemplate.getConnection().setCatalog(Optional.ofNullable(database.getConfiguration().getDefaultSchema()).orElse("default"));
         }
         String clusterName = database.getClusterName();
         boolean isClustered = StringUtils.hasText(clusterName);

--- a/flyway-database-clickhouse/src/main/java/org/flywaydb/community/database/clickhouse/ClickHouseSchema.java
+++ b/flyway-database-clickhouse/src/main/java/org/flywaydb/community/database/clickhouse/ClickHouseSchema.java
@@ -34,21 +34,24 @@ public class ClickHouseSchema extends Schema<ClickHouseDatabase, ClickHouseTable
 
     @Override
     protected boolean doExists() throws SQLException {
-        int i = jdbcTemplate.queryForInt("SELECT COUNT() FROM system.databases WHERE name = ?", name);
+        ClickHouseConnection systemConnection = database.getSystemConnection();
+        int i = systemConnection.getJdbcTemplate().queryForInt("SELECT COUNT() FROM system.databases WHERE name = ?", name);
         return i > 0;
     }
 
     @Override
     protected boolean doEmpty() throws SQLException {
-        int i = jdbcTemplate.queryForInt("SELECT COUNT() FROM system.tables WHERE database = ?", name);
+        ClickHouseConnection systemConnection = database.getSystemConnection();
+        int i = systemConnection.getJdbcTemplate().queryForInt("SELECT COUNT() FROM system.tables WHERE database = ?", name);
         return i == 0;
     }
 
     @Override
     protected void doCreate() throws SQLException {
+        ClickHouseConnection systemConnection = database.getSystemConnection();
         String clusterName = database.getClusterName();
         boolean isClustered = StringUtils.hasText(clusterName);
-        jdbcTemplate.executeStatement("CREATE DATABASE " + database.quote(name) + (isClustered ? (" ON CLUSTER " + clusterName) : ""));
+        systemConnection.getJdbcTemplate().executeStatement("CREATE DATABASE " + database.quote(name) + (isClustered ? (" ON CLUSTER " + clusterName) : ""));
     }
 
     @Override
@@ -70,7 +73,8 @@ public class ClickHouseSchema extends Schema<ClickHouseDatabase, ClickHouseTable
 
     @Override
     protected ClickHouseTable[] doAllTables() throws SQLException {
-        return jdbcTemplate.queryForStringList("SELECT name FROM system.tables WHERE database = ?", name)
+        ClickHouseConnection systemConnection = database.getSystemConnection();
+        return systemConnection.getJdbcTemplate().queryForStringList("SELECT name FROM system.tables WHERE database = ?", name)
                 .stream()
                 .map(this::getTable)
                 .toArray(ClickHouseTable[]::new);

--- a/flyway-database-clickhouse/src/main/java/org/flywaydb/community/database/clickhouse/ClickHouseSchema.java
+++ b/flyway-database-clickhouse/src/main/java/org/flywaydb/community/database/clickhouse/ClickHouseSchema.java
@@ -17,8 +17,10 @@ package org.flywaydb.community.database.clickhouse;
 
 import org.flywaydb.core.internal.database.base.Schema;
 import org.flywaydb.core.internal.jdbc.JdbcTemplate;
+import org.flywaydb.core.internal.util.StringUtils;
 
 import java.sql.SQLException;
+import java.util.Optional;
 
 public class ClickHouseSchema extends Schema<ClickHouseDatabase, ClickHouseTable> {
     /**
@@ -44,7 +46,9 @@ public class ClickHouseSchema extends Schema<ClickHouseDatabase, ClickHouseTable
 
     @Override
     protected void doCreate() throws SQLException {
-        jdbcTemplate.executeStatement("CREATE DATABASE " + database.quote(name));
+        String clusterName = database.getClusterName();
+        boolean isClustered = StringUtils.hasText(clusterName);
+        jdbcTemplate.executeStatement("CREATE DATABASE " + database.quote(name) + (isClustered ? (" ON CLUSTER " + clusterName) : ""));
     }
 
     @Override
@@ -52,7 +56,9 @@ public class ClickHouseSchema extends Schema<ClickHouseDatabase, ClickHouseTable
         if (jdbcTemplate.getConnection().getSchema().equals(name)) {
             jdbcTemplate.getConnection().setSchema("default");
         }
-        jdbcTemplate.executeStatement("DROP DATABASE " + database.quote(name));
+        String clusterName = database.getClusterName();
+        boolean isClustered = StringUtils.hasText(clusterName);
+        jdbcTemplate.executeStatement("DROP DATABASE " + database.quote(name) + (isClustered ? (" ON CLUSTER " + clusterName) : ""));
     }
 
     @Override

--- a/flyway-database-clickhouse/src/main/java/org/flywaydb/community/database/clickhouse/ClickHouseTable.java
+++ b/flyway-database-clickhouse/src/main/java/org/flywaydb/community/database/clickhouse/ClickHouseTable.java
@@ -43,7 +43,8 @@ public class ClickHouseTable extends Table<ClickHouseDatabase, ClickHouseSchema>
 
     @Override
     protected boolean doExists() throws SQLException {
-        int count = jdbcTemplate.queryForInt("SELECT COUNT() FROM system.tables WHERE database = ? AND name = ?", schema.getName(), name);
+        ClickHouseConnection systemConnection = database.getSystemConnection();
+        int count = systemConnection.getJdbcTemplate().queryForInt("SELECT COUNT() FROM system.tables WHERE database = ? AND name = ?", schema.getName(), name);
         return count > 0;
     }
 

--- a/flyway-database-ignite/pom.xml
+++ b/flyway-database-ignite/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.flywaydb</groupId>
         <artifactId>flyway-community-db-support</artifactId>
-        <version>10.7.0</version>
+        <version>10.7.1</version>
     </parent>
 
     <artifactId>flyway-database-ignite</artifactId>

--- a/flyway-database-oceanbase/pom.xml
+++ b/flyway-database-oceanbase/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.flywaydb</groupId>
         <artifactId>flyway-community-db-support</artifactId>
-        <version>10.7.0</version>
+        <version>10.7.1</version>
     </parent>
 
     <artifactId>flyway-database-oceanbase</artifactId>
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>flyway-mysql</artifactId>
-            <version>10.6.0</version>
+            <version>10.7.1</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.flywaydb</groupId>

--- a/flyway-database-tidb/pom.xml
+++ b/flyway-database-tidb/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.flywaydb</groupId>
         <artifactId>flyway-community-db-support</artifactId>
-        <version>10.7.0</version>
+        <version>10.7.1</version>
     </parent>
 
     <artifactId>flyway-database-tidb</artifactId>
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>flyway-mysql</artifactId>
-            <version>10.6.0</version>
+            <version>10.7.1</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.flywaydb</groupId>

--- a/flyway-database-yugabytedb/pom.xml
+++ b/flyway-database-yugabytedb/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.flywaydb</groupId>
         <artifactId>flyway-community-db-support</artifactId>
-        <version>10.7.0</version>
+        <version>10.7.1</version>
     </parent>
 
     <artifactId>flyway-database-yugabytedb</artifactId>
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>flyway-database-postgresql</artifactId>
-            <version>10.6.0</version>
+            <version>10.7.1</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.flywaydb</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -21,14 +21,14 @@
     <parent>
         <groupId>org.flywaydb</groupId>
         <artifactId>flyway-parent</artifactId>
-        <version>10.6.0</version>
+        <version>10.7.1</version>
         <relativePath/>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>flyway-community-db-support</artifactId>
     <packaging>pom</packaging>
-    <version>10.7.0</version>
+    <version>10.7.1</version>
     <name>${project.artifactId}</name>
 
     <modules>
@@ -44,7 +44,7 @@
             <dependency>
                 <groupId>${project.groupId}</groupId>
                 <artifactId>flyway-core</artifactId>
-                <version>10.6.0</version>
+                <version>10.7.1</version>
                 <scope>provided</scope>
             </dependency>
         </dependencies>


### PR DESCRIPTION
I tried to make the clickhouse community plugin work on our setup, but had to make a few changes:

- Adding "ON CLUSTER" to DDL's, to have the changes reproduced on all nodes.
- Adding a systemConnection in ClickHouseDatabase - this one is a bit surprising to me, but I got a "Database the_database doesn't exist" error when executing `jdbcTemplate.queryForInt("SELECT COUNT() FROM system.tables WHERE database = ?", name)`. Even though I am not accessing `the_database`, the connection is configured to use it, so I get an exception.
- Using getCatalog instead of getSchema. This is kinda optional, but it appears that with `clickhouse-jdbc:0.5.0` and newer versions, catalog is used instead of schema (can be overridden using `?databaseTerm=schema` in the jdbc-url).

Each change is in a separate commit.