### PR TITLE
[ClickHouse] Add support for schema switching with older JDBC drivers

### DIFF
--- a/flyway-database-clickhouse/src/main/java/org/flywaydb/community/database/clickhouse/ClickHouseConnection.java
+++ b/flyway-database-clickhouse/src/main/java/org/flywaydb/community/database/clickhouse/ClickHouseConnection.java
@@ -52,6 +52,6 @@ public class ClickHouseConnection extends Connection<ClickHouseDatabase> {
 
     @Override
     public ClickHouseSchema getSchema(String name) {
-        return new ClickHouseSchema(getJdbcTemplate(), database, name);
+        return new ClickHouseSchema(jdbcTemplate, database, name);
     }
 }

--- a/flyway-database-clickhouse/src/main/java/org/flywaydb/community/database/clickhouse/ClickHouseSchema.java
+++ b/flyway-database-clickhouse/src/main/java/org/flywaydb/community/database/clickhouse/ClickHouseSchema.java
@@ -23,6 +23,9 @@ import java.sql.SQLException;
 import java.util.Optional;
 
 public class ClickHouseSchema extends Schema<ClickHouseDatabase, ClickHouseTable> {
+
+    private static final String DEFAULT_SCHEMA = "default";
+
     /**
      * @param jdbcTemplate The Jdbc Template for communicating with the DB.
      * @param database The database-specific support.
@@ -56,8 +59,8 @@ public class ClickHouseSchema extends Schema<ClickHouseDatabase, ClickHouseTable
 
     @Override
     protected void doDrop() throws SQLException {
-        if (jdbcTemplate.getConnection().getCatalog().equals(name)) {
-            jdbcTemplate.getConnection().setCatalog(Optional.ofNullable(database.getConfiguration().getDefaultSchema()).orElse("default"));
+        if (database.getMainConnection().getCurrentSchemaNameOrSearchPath().equals(name)) {
+            database.getMainConnection().doChangeCurrentSchemaOrSearchPathTo(Optional.ofNullable(database.getConfiguration().getDefaultSchema()).orElse(DEFAULT_SCHEMA));
         }
         String clusterName = database.getClusterName();
         boolean isClustered = StringUtils.hasText(clusterName);


### PR DESCRIPTION
Since JDBC driver 0.5.0 we need to check "connection.getJdbcConfig().useCatalog()" property to find out what method to call to set the current schema: jdbcConnection.setCatalog() or jdbcConnection.setSchema().
The same thing is for obtaining the current schema from JDBC connection.