### PR TITLE
Add version number print support

### DIFF
--- a/flyway-database-clickhouse/src/main/java/org/flywaydb/community/database/ClickHouseDatabaseExtension.java
+++ b/flyway-database-clickhouse/src/main/java/org/flywaydb/community/database/ClickHouseDatabaseExtension.java
@@ -27,7 +27,7 @@ public class ClickHouseDatabaseExtension implements PluginMetadata {
         return "Community-contributed ClickHouse database support extension " + readVersion() + " by Redgate";
     }
 
-    private static String readVersion() {
+    public static String readVersion() {
         try {
             return FileUtils.copyToString(
                     ClickHouseDatabaseExtension.class.getClassLoader().getResourceAsStream("org/flywaydb/community/database/clickhouse/version.txt"),

--- a/flyway-database-clickhouse/src/main/java/org/flywaydb/community/database/clickhouse/ClickHouseDatabaseType.java
+++ b/flyway-database-clickhouse/src/main/java/org/flywaydb/community/database/clickhouse/ClickHouseDatabaseType.java
@@ -15,6 +15,7 @@
  */
 package org.flywaydb.community.database.clickhouse;
 
+import org.flywaydb.community.database.ClickHouseDatabaseExtension;
 import org.flywaydb.core.api.ResourceProvider;
 import org.flywaydb.core.api.configuration.Configuration;
 import org.flywaydb.core.internal.database.base.BaseDatabaseType;
@@ -74,5 +75,10 @@ public class ClickHouseDatabaseType extends BaseDatabaseType {
     @Override
     public boolean detectPasswordRequiredByUrl(String url) {
         return !url.contains("password=");
+    }
+
+    @Override
+    public String getPluginVersion(Configuration config) {
+        return ClickHouseDatabaseExtension.readVersion();
     }
 }

--- a/flyway-database-ignite/src/main/java/org/flywaydb/community/database/IgniteDatabaseExtension.java
+++ b/flyway-database-ignite/src/main/java/org/flywaydb/community/database/IgniteDatabaseExtension.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) Red Gate Software Ltd 2010-2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.community.database;
+
+import org.flywaydb.core.api.FlywayException;
+import org.flywaydb.core.extensibility.PluginMetadata;
+import org.flywaydb.core.internal.util.FileUtils;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+public class IgniteDatabaseExtension implements PluginMetadata {
+    public String getDescription() {
+        return "Community-contributed Ignite database support extension " + readVersion() + " by Redgate";
+    }
+
+    public static String readVersion() {
+        try {
+            return FileUtils.copyToString(
+                    IgniteDatabaseExtension.class.getClassLoader().getResourceAsStream("org/flywaydb/community/database/ignite/version.txt"),
+                    StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new FlywayException("Unable to read extension version: " + e.getMessage(), e);
+        }
+    }
+}

--- a/flyway-database-ignite/src/main/java/org/flywaydb/community/database/ignite/thin/IgniteThinDatabaseType.java
+++ b/flyway-database-ignite/src/main/java/org/flywaydb/community/database/ignite/thin/IgniteThinDatabaseType.java
@@ -15,6 +15,7 @@
  */
 package org.flywaydb.community.database.ignite.thin;
 
+import org.flywaydb.community.database.IgniteDatabaseExtension;
 import org.flywaydb.core.api.ResourceProvider;
 import org.flywaydb.core.api.configuration.Configuration;
 import org.flywaydb.core.internal.database.base.Database;
@@ -68,5 +69,10 @@ public class IgniteThinDatabaseType extends BaseDatabaseType {
     @Override
     public Parser createParser(Configuration configuration, ResourceProvider resourceProvider, ParsingContext parsingContext) {
         return new IgniteThinParser(configuration, parsingContext);
+    }
+
+    @Override
+    public String getPluginVersion(Configuration config) {
+        return IgniteDatabaseExtension.readVersion();
     }
 }

--- a/flyway-database-ignite/src/main/resources/org/flywaydb/community/database/ignite/version.txt
+++ b/flyway-database-ignite/src/main/resources/org/flywaydb/community/database/ignite/version.txt
@@ -1,0 +1,1 @@
+${pom.version}

--- a/flyway-database-oceanbase/src/main/java/org/flywaydb/community/database/OceanBaseDatabaseExtension.java
+++ b/flyway-database-oceanbase/src/main/java/org/flywaydb/community/database/OceanBaseDatabaseExtension.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) Red Gate Software Ltd 2010-2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.community.database;
+
+import org.flywaydb.core.api.FlywayException;
+import org.flywaydb.core.extensibility.PluginMetadata;
+import org.flywaydb.core.internal.util.FileUtils;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+public class OceanBaseDatabaseExtension implements PluginMetadata {
+    public String getDescription() {
+        return "Community-contributed OceanBase database support extension " + readVersion() + " by Redgate";
+    }
+
+    public static String readVersion() {
+        try {
+            return FileUtils.copyToString(
+                    OceanBaseDatabaseExtension.class.getClassLoader().getResourceAsStream("org/flywaydb/community/database/oceanbase/version.txt"),
+                    StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new FlywayException("Unable to read extension version: " + e.getMessage(), e);
+        }
+    }
+}

--- a/flyway-database-oceanbase/src/main/java/org/flywaydb/community/database/oceanbase/OceanBaseDatabaseType.java
+++ b/flyway-database-oceanbase/src/main/java/org/flywaydb/community/database/oceanbase/OceanBaseDatabaseType.java
@@ -15,6 +15,7 @@
  */
 package org.flywaydb.community.database.oceanbase;
 
+import org.flywaydb.community.database.OceanBaseDatabaseExtension;
 import org.flywaydb.core.api.ResourceProvider;
 import org.flywaydb.core.api.configuration.Configuration;
 import org.flywaydb.core.internal.database.base.BaseDatabaseType;
@@ -95,5 +96,10 @@ public class OceanBaseDatabaseType extends BaseDatabaseType {
     @Override
     public Parser createParser(Configuration configuration, ResourceProvider resourceProvider, ParsingContext parsingContext) {
         return new MySQLParser(configuration, parsingContext);
+    }
+
+    @Override
+    public String getPluginVersion(Configuration config) {
+        return OceanBaseDatabaseExtension.readVersion();
     }
 }

--- a/flyway-database-oceanbase/src/main/resources/org/flywaydb/community/database/oceanbase/version.txt
+++ b/flyway-database-oceanbase/src/main/resources/org/flywaydb/community/database/oceanbase/version.txt
@@ -1,0 +1,1 @@
+${pom.version}

--- a/flyway-database-tidb/src/main/java/org/flywaydb/community/database/TiDBDatabaseExtension.java
+++ b/flyway-database-tidb/src/main/java/org/flywaydb/community/database/TiDBDatabaseExtension.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) Red Gate Software Ltd 2010-2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.community.database;
+
+import org.flywaydb.core.api.FlywayException;
+import org.flywaydb.core.extensibility.PluginMetadata;
+import org.flywaydb.core.internal.util.FileUtils;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+public class TiDBDatabaseExtension implements PluginMetadata {
+    public String getDescription() {
+        return "Community-contributed TiDB database support extension " + readVersion() + " by Redgate";
+    }
+
+    public static String readVersion() {
+        try {
+            return FileUtils.copyToString(
+                    TiDBDatabaseExtension.class.getClassLoader().getResourceAsStream("org/flywaydb/community/database/tidb/version.txt"),
+                    StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new FlywayException("Unable to read extension version: " + e.getMessage(), e);
+        }
+    }
+}

--- a/flyway-database-tidb/src/main/java/org/flywaydb/community/database/mysql/tidb/TiDBDatabaseType.java
+++ b/flyway-database-tidb/src/main/java/org/flywaydb/community/database/mysql/tidb/TiDBDatabaseType.java
@@ -15,6 +15,7 @@
  */
 package org.flywaydb.community.database.mysql.tidb;
 
+import org.flywaydb.community.database.TiDBDatabaseExtension;
 import org.flywaydb.core.api.configuration.Configuration;
 import org.flywaydb.core.internal.database.base.Database;
 import org.flywaydb.database.mysql.MySQLConnection;
@@ -45,5 +46,10 @@ public class TiDBDatabaseType extends MySQLDatabaseType {
     @Override
     public Database createDatabase(Configuration configuration, JdbcConnectionFactory jdbcConnectionFactory, StatementInterceptor statementInterceptor) {
         return new TiDBDatabase(configuration, jdbcConnectionFactory, statementInterceptor);
+    }
+
+    @Override
+    public String getPluginVersion(Configuration config) {
+        return TiDBDatabaseExtension.readVersion();
     }
 }

--- a/flyway-database-tidb/src/main/resources/org/flywaydb/community/database/tidb/version.txt
+++ b/flyway-database-tidb/src/main/resources/org/flywaydb/community/database/tidb/version.txt
@@ -1,0 +1,1 @@
+${pom.version}

--- a/flyway-database-yugabytedb/src/main/java/org/flywaydb/community/database/YugabyteDBDatabaseExtension.java
+++ b/flyway-database-yugabytedb/src/main/java/org/flywaydb/community/database/YugabyteDBDatabaseExtension.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) Red Gate Software Ltd 2010-2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.community.database;
+
+import org.flywaydb.core.api.FlywayException;
+import org.flywaydb.core.extensibility.PluginMetadata;
+import org.flywaydb.core.internal.util.FileUtils;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+public class YugabyteDBDatabaseExtension implements PluginMetadata {
+    public String getDescription() {
+        return "Community-contributed YugabyteDB database support extension " + readVersion() + " by Redgate";
+    }
+
+    public static String readVersion() {
+        try {
+            return FileUtils.copyToString(
+                    YugabyteDBDatabaseExtension.class.getClassLoader().getResourceAsStream("org/flywaydb/community/database/yugabytedb/version.txt"),
+                    StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new FlywayException("Unable to read extension version: " + e.getMessage(), e);
+        }
+    }
+}

--- a/flyway-database-yugabytedb/src/main/java/org/flywaydb/community/database/postgresql/yugabytedb/YugabyteDBDatabaseType.java
+++ b/flyway-database-yugabytedb/src/main/java/org/flywaydb/community/database/postgresql/yugabytedb/YugabyteDBDatabaseType.java
@@ -15,6 +15,7 @@
  */
 package org.flywaydb.community.database.postgresql.yugabytedb;
 
+import org.flywaydb.community.database.YugabyteDBDatabaseExtension;
 import org.flywaydb.core.api.ResourceProvider;
 import org.flywaydb.core.api.configuration.Configuration;
 import org.flywaydb.core.internal.database.base.Database;
@@ -59,5 +60,10 @@ public class YugabyteDBDatabaseType extends PostgreSQLDatabaseType {
     @Override
     public Parser createParser(Configuration configuration, ResourceProvider resourceProvider, ParsingContext parsingContext) {
         return new YugabyteDBParser(configuration, parsingContext);
+    }
+
+    @Override
+    public String getPluginVersion(Configuration config) {
+        return YugabyteDBDatabaseExtension.readVersion();
     }
 }

--- a/flyway-database-yugabytedb/src/main/resources/org/flywaydb/community/database/yugabytedb/version.txt
+++ b/flyway-database-yugabytedb/src/main/resources/org/flywaydb/community/database/yugabytedb/version.txt
@@ -1,0 +1,1 @@
+${pom.version}


### PR DESCRIPTION
Implement the `getPluginVersion` method for every community supported DBs.
 
When running `Flyway version`, we can get a output as below:

![image](https://github.com/flyway/flyway-community-db-support/assets/130552403/c41ea1c5-8cb3-49c3-bba8-12eefdfbccd0)
