### PR TITLE
[Clickhouse] Fix systemConnection connection leak

### DIFF
--- a/flyway-database-clickhouse/src/main/java/org/flywaydb/community/database/clickhouse/ClickHouseDatabase.java
+++ b/flyway-database-clickhouse/src/main/java/org/flywaydb/community/database/clickhouse/ClickHouseDatabase.java
@@ -101,6 +101,15 @@ public class ClickHouseDatabase extends Database<ClickHouseConnection> {
     }
 
     @Override
+    public void close() {
+        if (systemConnection != null) {
+            systemConnection.close();
+        }
+
+        super.close();
+    }
+
+    @Override
     public String getRawCreateScript(Table table, boolean baseline) {
         String clusterName = getClusterName();
         boolean isClustered = StringUtils.hasText(clusterName);


### PR DESCRIPTION
System connection aren't closed after it was used. It's because the close() method was not overridden.

In general: If you use a connection pool like HikariCP, the connection isn't returned back to the pool.