### PR TITLE
compatible with OceanBase Connector/J 2.4.9

### DIFF
--- a/flyway-database-oceanbase/src/main/java/org/flywaydb/community/database/oceanbase/OceanBaseDatabaseType.java
+++ b/flyway-database-oceanbase/src/main/java/org/flywaydb/community/database/oceanbase/OceanBaseDatabaseType.java
@@ -73,7 +73,7 @@ public class OceanBaseDatabaseType extends MySQLDatabaseType implements Communit
 
     @Override
     public boolean handlesDatabaseProductNameAndVersion(String databaseProductName, String databaseProductVersion, Connection connection) {
-        if (!databaseProductName.contains("MySQL")) {
+        if (!databaseProductName.contains("MySQL") && !databaseProductName.contains("OceanBase")) {
             return false;
         }
 


### PR DESCRIPTION
OceanBase Connector/J 2.4.9 getDatabaseProductName return 'OceanBase' not 'MySql' without useCompatibleMetadata option.