### PR TITLE
Separate Archetype deployment due to Maven properties bug

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -27,6 +27,11 @@ jobs:
         run: mvn -B install --file pom.xml
       - name: Publish to GitHub Packages Apache Maven
         if: contains(github.ref, 'main')
-        run: mvn -B deploy -Pgithub -s $GITHUB_WORKSPACE/settings.xml
+        run: mvn -B deploy -Pgithub -s $GITHUB_WORKSPACE/settings.xml -pl '!flyway-community-db-support-archetype'
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+      - name: Publish Archetype to GitHub Packages Apache Maven
+        if: contains(github.ref, 'main')
+        run: mvn -B deploy -Pgithub -s $GITHUB_WORKSPACE/settings.xml -pl flyway-community-db-support-archetype
         env:
           GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Due to a bug with Maven overriding deployment parameters between projects which do not share a parent. This deploys the community archetype separately from the rest of the project