### PR TITLE
[YugabyteDB plugin] Use single connection for both schema history table management and applying migrations

### DIFF
--- a/flyway-database-yugabytedb/src/main/java/org/flywaydb/community/database/postgresql/yugabytedb/YugabyteDBDatabase.java
+++ b/flyway-database-yugabytedb/src/main/java/org/flywaydb/community/database/postgresql/yugabytedb/YugabyteDBDatabase.java
@@ -77,18 +77,9 @@ public class YugabyteDBDatabase extends PostgreSQLDatabase {
                 "CREATE INDEX IF NOT EXISTS \"" + table.getName() + "_s_idx\" ON " + table + " (\"success\");";
     }
 
-    /**
-     * YugabyteDB does not support PG Advisor Locks. So the YugabyteDB plugin
-     * employs SELECT ... FOR UPDATE in a transaction to implement locking for
-     * Flyway operations instead of the PG Advisory locks. If a single
-     * connection is used, it may cause issues if multiple threads execute
-     * begin/commit on it for Flyway operations. Returning false from this
-     * method ensures the same connection is not used for migrations.
-     * @return false
-     */
     @Override
     public boolean useSingleConnection() {
-        return false;
+        return true;
     }
 
     private void createLockTable() {

--- a/flyway-database-yugabytedb/src/main/java/org/flywaydb/community/database/postgresql/yugabytedb/YugabyteDBExecutionTemplate.java
+++ b/flyway-database-yugabytedb/src/main/java/org/flywaydb/community/database/postgresql/yugabytedb/YugabyteDBExecutionTemplate.java
@@ -8,16 +8,16 @@ import org.flywaydb.core.internal.strategy.RetryStrategy;
 import org.flywaydb.core.internal.util.FlywayDbWebsiteLinks;
 
 import java.sql.*;
-import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentHashMap;
 
 @CustomLog
 public class YugabyteDBExecutionTemplate {
 
     private final JdbcTemplate jdbcTemplate;
     private final String tableName;
-    private final HashMap<String, Boolean> tableEntries = new HashMap<>();
-
+    private static final Map<String, Boolean> tableEntries = new ConcurrentHashMap<>();
 
     YugabyteDBExecutionTemplate(JdbcTemplate jdbcTemplate, String tableName) {
         this.jdbcTemplate = jdbcTemplate;


### PR DESCRIPTION
## What
- Fix for GH Issue https://github.com/yugabyte/yugabyte-db/issues/23327
  - Currently, the plugin uses a separate connection to manage schema history table and migrations are applied in another thread.
  - This was causing catalog version mismatch issues when one thread altered catalog version while another was querying a `pg_catalog.pg_class` table inside a transaction.
  - The fix is to use single connection for both schema history table management and applying migrations
- Also, made the `tableEntries` map a static variable in `YugabyteDBExecutionTemplate`
  - This map keeps track of which entries are added to the lock table across different migrations from within the same app. Earlier, being an instance variable it was getting reinitialised for each migration and not serving its purpose.

## Testing
Ran modified tests from flyway-tests repository. PR available https://github.com/yugabyte/flyway-tests/pull/3.