### PR TITLE
Update DB2ZDatabase.java with new DB2 for z/OS versions

### DIFF
--- a/flyway-database-db2zos/src/main/java/org/flywaydb/community/database/db2z/DB2ZDatabase.java
+++ b/flyway-database-db2zos/src/main/java/org/flywaydb/community/database/db2z/DB2ZDatabase.java
@@ -57,11 +57,11 @@ public class DB2ZDatabase extends Database<DB2ZConnection> {
 
     @Override
     public void ensureSupported(Configuration configuration) {
-        ensureDatabaseIsRecentEnough("10.0");
+        ensureDatabaseIsRecentEnough("12.1");
 
-        ensureDatabaseNotOlderThanOtherwiseRecommendUpgradeToFlywayEdition("11.0", Tier.PREMIUM, configuration);
+        //ensureDatabaseNotOlderThanOtherwiseRecommendUpgradeToFlywayEdition("12.1", Tier.PREMIUM, configuration);
 
-        recommendFlywayUpgradeIfNecessary("12.1");
+        recommendFlywayUpgradeIfNecessary("13.1");
     }
 
     @Override


### PR DESCRIPTION
DB2 for z/OS v11.1 has been withdrawn from support by IBM, and DB2 for z/OS  v13.1 is the current version, with which I now also test the db2z plugin.