### PR TITLE
Timeplus Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,4 @@ buildNumber.properties
 *_LOCAL_*.txt
 *_REMOTE_*.txt
 
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,4 @@ buildNumber.properties
 *_REMOTE_*.txt
 
 .DS_Store
+*.cfg

--- a/flyway-database-timeplus/pom.xml
+++ b/flyway-database-timeplus/pom.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) Red Gate Software Ltd 2010-2024
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.flywaydb</groupId>
+        <artifactId>flyway-community-db-support</artifactId>
+        <version>10.16.3</version>
+    </parent>
+
+    <artifactId>flyway-database-timeplus</artifactId>
+    <name>${project.artifactId}</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>flyway-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.timeplus</groupId>
+            <artifactId>timeplus-native-jdbc</artifactId>
+            <version>2.0.7</version>
+            <optional>true</optional>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+        <plugins>
+            <plugin>
+                <artifactId>maven-resources-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/flyway-database-timeplus/src/main/java/org/flywaydb/community/database/TimeplusDatabaseExtension.java
+++ b/flyway-database-timeplus/src/main/java/org/flywaydb/community/database/TimeplusDatabaseExtension.java
@@ -1,0 +1,58 @@
+/*-
+ * ========================LICENSE_START=================================
+ * flyway-database-timeplus
+ * ========================================================================
+ * Copyright (C) 2010 - 2024 Red Gate Software Ltd
+ * ========================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+/*
+ * Copyright (C) Red Gate Software Ltd 2010-2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.community.database;
+
+import org.flywaydb.core.api.FlywayException;
+import org.flywaydb.core.extensibility.PluginMetadata;
+import org.flywaydb.core.internal.util.FileUtils;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+public class TimeplusDatabaseExtension implements PluginMetadata {
+    public String getDescription() {
+        return "Community-contributed Timeplus database support extension " + readVersion();
+    }
+
+    public static String readVersion() {
+        try {
+            return FileUtils.copyToString(
+                    TimeplusDatabaseExtension.class.getClassLoader().getResourceAsStream("org/flywaydb/community/database/timeplus/version.txt"),
+                    StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new FlywayException("Unable to read extension version: " + e.getMessage(), e);
+        }
+    }
+}

--- a/flyway-database-timeplus/src/main/java/org/flywaydb/community/database/timeplus/TimeplusConfigurationExtension.java
+++ b/flyway-database-timeplus/src/main/java/org/flywaydb/community/database/timeplus/TimeplusConfigurationExtension.java
@@ -1,0 +1,80 @@
+/*-
+ * ========================LICENSE_START=================================
+ * flyway-database-timeplus
+ * ========================================================================
+ * Copyright (C) 2010 - 2024 Red Gate Software Ltd
+ * ========================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+/*
+ * Copyright (C) Red Gate Software Ltd 2010-2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.community.database.timeplus;
+
+import lombok.Getter;
+import org.flywaydb.core.extensibility.ConfigurationExtension;
+
+import java.util.Map;
+
+@Getter
+public class TimeplusConfigurationExtension implements ConfigurationExtension {
+    private static final String CLUSTER_NAME = "flyway.timeplus.clusterName";
+    private static final String ZOOKEEPER_PATH = "flyway.timeplus.zookeeperPath";
+
+    private static final String ZOOKEEPER_PATH_DEFAULT_VALUE = "/timeplus/tables/{shard}/{database}/{table}";
+
+    private String clusterName;
+    private String zookeeperPath = ZOOKEEPER_PATH_DEFAULT_VALUE;
+
+    @Override
+    public String getNamespace() {
+        return "timeplus";
+    }
+
+    @Override
+    public void extractParametersFromConfiguration(Map<String, String> configuration) {
+        String clusterName = configuration.remove(CLUSTER_NAME);
+        if (clusterName != null) {
+            this.clusterName = clusterName;
+        }
+
+        String zookeeperPath = configuration.remove(ZOOKEEPER_PATH);
+        if (zookeeperPath != null) {
+            this.zookeeperPath = zookeeperPath;
+        }
+    }
+
+    @Override
+    public String getConfigurationParameterFromEnvironmentVariable(String environmentVariable) {
+        if ("FLYWAY_TIMEPLUS_CLUSTER_NAME".equals(environmentVariable)) {
+            return CLUSTER_NAME;
+        }
+        if ("FLYWAY_TIMEPLUS_ZOOKEEPER_PATH".equals(environmentVariable)) {
+            return ZOOKEEPER_PATH;
+        }
+        return null;
+    }
+}

--- a/flyway-database-timeplus/src/main/java/org/flywaydb/community/database/timeplus/TimeplusConnection.java
+++ b/flyway-database-timeplus/src/main/java/org/flywaydb/community/database/timeplus/TimeplusConnection.java
@@ -1,0 +1,80 @@
+/*-
+ * ========================LICENSE_START=================================
+ * flyway-database-timeplus
+ * ========================================================================
+ * Copyright (C) 2010 - 2024 Red Gate Software Ltd
+ * ========================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+/*
+ * Copyright (C) Red Gate Software Ltd 2010-2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.community.database.timeplus;
+
+import org.flywaydb.core.internal.database.base.Connection;
+
+import java.sql.SQLException;
+import java.util.Optional;
+
+public class TimeplusConnection extends Connection<TimeplusDatabase> {
+    private static final String DEFAULT_CATALOG_TERM = "database";
+
+    TimeplusConnection(TimeplusDatabase database, java.sql.Connection connection) {
+        super(database, connection);
+    }
+
+    @Override
+    protected String getCurrentSchemaNameOrSearchPath() throws SQLException {
+        var jdbcConnection = getJdbcTemplate().getConnection();
+        var currentSchema = useCatalog(jdbcConnection) ?
+                jdbcConnection.getCatalog() : jdbcConnection.getSchema();
+
+        return Optional.ofNullable(currentSchema).map(database::unQuote).orElse(null);
+    }
+
+    @Override
+    public void doChangeCurrentSchemaOrSearchPathTo(String schema) throws SQLException {
+        // databaseTerm is catalog since driver version 0.5.0
+        // https://github.com/Timeplus/timeplus-java/issues/1273 & https://github.com/dbeaver/dbeaver/issues/19383
+        // For compatibility with old libraries, ((TimeplusConnection) getJdbcConnection()).useCatalog() should be checked
+        var jdbcConnection = getJdbcTemplate().getConnection();
+
+        if (useCatalog(jdbcConnection)) {
+            jdbcConnection.setCatalog(schema);
+        } else {
+            jdbcConnection.setSchema(schema);
+        }
+    }
+
+    protected boolean useCatalog(java.sql.Connection jdbcConnection) throws SQLException {
+        return DEFAULT_CATALOG_TERM.equals(jdbcConnection.getMetaData().getCatalogTerm());
+    }
+
+    @Override
+    public TimeplusSchema getSchema(String name) {
+        return new TimeplusSchema(jdbcTemplate, database, name);
+    }
+}

--- a/flyway-database-timeplus/src/main/java/org/flywaydb/community/database/timeplus/TimeplusDatabase.java
+++ b/flyway-database-timeplus/src/main/java/org/flywaydb/community/database/timeplus/TimeplusDatabase.java
@@ -133,31 +133,29 @@ public class TimeplusDatabase extends Database<TimeplusConnection> {
         String clusterName = getClusterName();
         boolean isClustered = StringUtils.hasText(clusterName);
 
-        String script = "CREATE STREAM IF NOT EXISTS " + table + (false&&isClustered ? (" ON CLUSTER " + clusterName) : "") + "(" +
-                "    installed_rank int32," +
-                "    version nullable(string)," +
-                "    description string," +
-                "    type string," +
-                "    script string," +
-                "    checksum nullable(int32)," +
-                "    installed_by string," +
-                "    installed_on datetime DEFAULT now()," +
-                "    execution_time int32," +
-                "    success bool" +
+        String script = "CREATE STREAM IF NOT EXISTS " + table + (isClustered ? (" ON CLUSTER " + clusterName) : "") + "(" +
+                        "    installed_rank int32," +
+                        "    version nullable(string)," +
+                        "    description string," +
+                        "    type string," +
+                        "    script string," +
+                        "    checksum nullable(int32)," +
+                        "    installed_by string," +
+                        "    installed_on datetime DEFAULT now()," +
+                        "    execution_time int32," +
+                        "    success bool" +
                 ")";
 
         String engine;
 
-        /*
         if (isClustered) {
             engine = "ReplicatedMergeTree('" + getZookeeperPath() + "', '{replica}')";
         } else {
             engine = "MergeTree";
         }
-        */
 
-        script += //" ENGINE = " + engine +
-                  " PRIMARY KEY (script);";
+        script += " ENGINE = " + engine +
+                " PRIMARY KEY (script);";
 
         return script + (baseline ? getBaselineStatement(table) + ";" : "");
     }

--- a/flyway-database-timeplus/src/main/java/org/flywaydb/community/database/timeplus/TimeplusDatabase.java
+++ b/flyway-database-timeplus/src/main/java/org/flywaydb/community/database/timeplus/TimeplusDatabase.java
@@ -1,0 +1,164 @@
+/*-
+ * ========================LICENSE_START=================================
+ * flyway-database-timeplus
+ * ========================================================================
+ * Copyright (C) 2010 - 2024 Red Gate Software Ltd
+ * ========================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+/*
+ * Copyright (C) Red Gate Software Ltd 2010-2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.community.database.timeplus;
+
+import org.flywaydb.core.api.configuration.Configuration;
+import org.flywaydb.core.internal.database.base.Database;
+import org.flywaydb.core.internal.database.base.Table;
+import org.flywaydb.core.internal.exception.FlywaySqlException;
+import org.flywaydb.core.internal.jdbc.JdbcConnectionFactory;
+import org.flywaydb.core.internal.jdbc.StatementInterceptor;
+import org.flywaydb.core.internal.util.StringUtils;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+public class TimeplusDatabase extends Database<TimeplusConnection> {
+
+    private TimeplusConnection systemConnection;
+
+    @Override
+    public boolean useSingleConnection() {
+        return true;
+    }
+
+    public TimeplusDatabase(Configuration configuration, JdbcConnectionFactory jdbcConnectionFactory, StatementInterceptor statementInterceptor) {
+        super(configuration, jdbcConnectionFactory, statementInterceptor);
+    }
+
+    public String getClusterName() {
+        return configuration.getPluginRegister().getPlugin(TimeplusConfigurationExtension.class).getClusterName();
+    }
+
+    public String getZookeeperPath() {
+        return configuration.getPluginRegister().getPlugin(TimeplusConfigurationExtension.class).getZookeeperPath();
+    }
+
+    public TimeplusConnection getSystemConnection() {
+        // Queries on system.XX fail with "Code: 81. DB::Exception: Database the_database doesn't exist. (UNKNOWN_DATABASE) (version 23.7.1.2470 (official build))"
+        // in case the current catalog (database) is not yet created.
+        // For this reason, we switch to an existing DB before execution. The database might not have been created yet, so we cannot reliably switch back the Schema.
+        //  * mainConnection cannot be used, as this would change the location of the schema history table.
+        //  * jdbcTemplate cannot be used, as this would change the location of the new tables.
+        // We had to introduce a separate connection, reserved to system database access.
+        if (systemConnection == null) {
+            Connection connection = jdbcConnectionFactory.openConnection();
+            try {
+                systemConnection = doGetConnection(connection);
+                systemConnection.doChangeCurrentSchemaOrSearchPathTo("system");
+            } catch (SQLException e) {
+                throw new FlywaySqlException("Unable to switch connection to read-only", e);
+            }
+        }
+        return systemConnection;
+    }
+
+    @Override
+    protected TimeplusConnection doGetConnection(Connection connection) {
+        return new TimeplusConnection(this, connection);
+    }
+
+    @Override
+    public void ensureSupported(Configuration configuration) {
+    }
+
+    @Override
+    public boolean supportsDdlTransactions() {
+        return false;
+    }
+
+    @Override
+    public boolean supportsMultiStatementTransactions() {
+        return false;
+    }
+
+    @Override
+    public String getBooleanTrue() {
+        return "1";
+    }
+
+    @Override
+    public String getBooleanFalse() {
+        return "0";
+    }
+
+    @Override
+    public boolean catalogIsSchema() {
+        return true;
+    }
+
+    @Override
+    public void close() {
+        if (systemConnection != null) {
+            systemConnection.close();
+        }
+
+        super.close();
+    }
+
+    @Override
+    public String getRawCreateScript(Table table, boolean baseline) {
+        String clusterName = getClusterName();
+        boolean isClustered = StringUtils.hasText(clusterName);
+
+        String script = "CREATE STREAM IF NOT EXISTS " + table + (false&&isClustered ? (" ON CLUSTER " + clusterName) : "") + "(" +
+                "    installed_rank int32," +
+                "    version nullable(string)," +
+                "    description string," +
+                "    type string," +
+                "    script string," +
+                "    checksum nullable(int32)," +
+                "    installed_by string," +
+                "    installed_on datetime DEFAULT now()," +
+                "    execution_time int32," +
+                "    success bool" +
+                ")";
+
+        String engine;
+
+        /*
+        if (isClustered) {
+            engine = "ReplicatedMergeTree('" + getZookeeperPath() + "', '{replica}')";
+        } else {
+            engine = "MergeTree";
+        }
+        */
+
+        script += //" ENGINE = " + engine +
+                  " PRIMARY KEY (script);";
+
+        return script + (baseline ? getBaselineStatement(table) + ";" : "");
+    }
+}

--- a/flyway-database-timeplus/src/main/java/org/flywaydb/community/database/timeplus/TimeplusDatabase.java
+++ b/flyway-database-timeplus/src/main/java/org/flywaydb/community/database/timeplus/TimeplusDatabase.java
@@ -40,6 +40,7 @@ import org.flywaydb.core.internal.database.base.Table;
 import org.flywaydb.core.internal.exception.FlywaySqlException;
 import org.flywaydb.core.internal.jdbc.JdbcConnectionFactory;
 import org.flywaydb.core.internal.jdbc.StatementInterceptor;
+import org.flywaydb.core.internal.util.Pair;
 import org.flywaydb.core.internal.util.StringUtils;
 
 import java.sql.Connection;
@@ -158,5 +159,11 @@ public class TimeplusDatabase extends Database<TimeplusConnection> {
                 " PRIMARY KEY (script);";
 
         return script + (baseline ? getBaselineStatement(table) + ";" : "");
+    }
+
+    @Override
+    public Pair<String, Object> getDeleteStatement(Table table, boolean version, String filter) {
+        String deleteStatement = "ALTER STREAM " + table + " DELETE WHERE " + this.quote("success") + " = " + this.getBooleanFalse() + " AND " + (version ? this.quote("version") + " = ?" : this.quote("description") + " = ?");
+        return Pair.of(deleteStatement, filter);
     }
 }

--- a/flyway-database-timeplus/src/main/java/org/flywaydb/community/database/timeplus/TimeplusDatabase.java
+++ b/flyway-database-timeplus/src/main/java/org/flywaydb/community/database/timeplus/TimeplusDatabase.java
@@ -166,4 +166,14 @@ public class TimeplusDatabase extends Database<TimeplusConnection> {
         String deleteStatement = "ALTER STREAM " + table + " DELETE WHERE " + this.quote("success") + " = " + this.getBooleanFalse() + " AND " + (version ? this.quote("version") + " = ?" : this.quote("description") + " = ?");
         return Pair.of(deleteStatement, filter);
     }
+
+    @Override
+    public String getUpdateStatement(Table table) {
+        return "ALTER STREAM " + table
+               + " UPDATE "
+               + quote("description") + "=? , "
+               + quote("type") + "=? , "
+               + quote("checksum") + "=?"
+               + " WHERE " + quote("installed_rank") + "=?";
+    }
 }

--- a/flyway-database-timeplus/src/main/java/org/flywaydb/community/database/timeplus/TimeplusDatabaseType.java
+++ b/flyway-database-timeplus/src/main/java/org/flywaydb/community/database/timeplus/TimeplusDatabaseType.java
@@ -1,0 +1,104 @@
+/*-
+ * ========================LICENSE_START=================================
+ * flyway-database-timeplus
+ * ========================================================================
+ * Copyright (C) 2010 - 2024 Red Gate Software Ltd
+ * ========================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+/*
+ * Copyright (C) Red Gate Software Ltd 2010-2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.community.database.timeplus;
+
+import org.flywaydb.community.database.TimeplusDatabaseExtension;
+import org.flywaydb.core.api.ResourceProvider;
+import org.flywaydb.core.api.configuration.Configuration;
+import org.flywaydb.core.internal.database.base.BaseDatabaseType;
+import org.flywaydb.core.internal.database.base.CommunityDatabaseType;
+import org.flywaydb.core.internal.jdbc.JdbcConnectionFactory;
+import org.flywaydb.core.internal.jdbc.StatementInterceptor;
+import org.flywaydb.core.internal.parser.Parser;
+import org.flywaydb.core.internal.parser.ParsingContext;
+
+import java.sql.Connection;
+
+public class TimeplusDatabaseType extends BaseDatabaseType implements CommunityDatabaseType {
+    @Override
+    public String getName() {
+        return "Timeplus";
+    }
+
+    @Override
+    public int getNullType() {
+        return 0;
+    }
+
+    @Override
+    public boolean handlesJDBCUrl(String url) {
+        return url.startsWith("jdbc:timeplus:");
+    }
+
+    @Override
+    public String getDriverClass(String url, ClassLoader classLoader) {
+        return "com.timeplus.jdbc.TimeplusDriver";
+    }
+
+    @Override
+    public String getBackupDriverClass(String url, ClassLoader classLoader) {
+        return "com.timeplus.jdbc.TimeplusDriver";
+    }
+
+    @Override
+    public boolean handlesDatabaseProductNameAndVersion(String databaseProductName, String databaseProductVersion, Connection connection) {
+        return databaseProductName.startsWith("Timeplus");
+    }
+
+    @Override
+    public TimeplusDatabase createDatabase(Configuration configuration, JdbcConnectionFactory jdbcConnectionFactory, StatementInterceptor statementInterceptor) {
+        return new TimeplusDatabase(configuration, jdbcConnectionFactory, statementInterceptor);
+    }
+
+    @Override
+    public Parser createParser(Configuration configuration, ResourceProvider resourceProvider, ParsingContext parsingContext) {
+        return new TimeplusParser(configuration, parsingContext, 3);
+    }
+
+    @Override
+    public boolean detectUserRequiredByUrl(String url) {
+        return !url.contains("user=");
+    }
+
+    @Override
+    public boolean detectPasswordRequiredByUrl(String url) {
+        return !url.contains("password=");
+    }
+
+    @Override
+    public String getPluginVersion(Configuration config) {
+        return TimeplusDatabaseExtension.readVersion();
+    }
+}

--- a/flyway-database-timeplus/src/main/java/org/flywaydb/community/database/timeplus/TimeplusParser.java
+++ b/flyway-database-timeplus/src/main/java/org/flywaydb/community/database/timeplus/TimeplusParser.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -35,11 +35,43 @@
 package org.flywaydb.community.database.timeplus;
 
 import org.flywaydb.core.api.configuration.Configuration;
-import org.flywaydb.core.internal.parser.Parser;
-import org.flywaydb.core.internal.parser.ParsingContext;
+import org.flywaydb.core.internal.parser.*;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
 
 public class TimeplusParser extends Parser {
+    private static final String ALTERNATIVE_QUOTE = "$$";
+
     protected TimeplusParser(Configuration configuration, ParsingContext parsingContext, int peekDepth) {
         super(configuration, parsingContext, peekDepth);
+    }
+
+    @Override
+    protected boolean isAlternativeStringLiteral(String peek) {
+        if (peek.startsWith(ALTERNATIVE_QUOTE)) {
+            return true;
+        }
+        return super.isAlternativeStringLiteral(peek);
+    }
+
+    @Override
+    protected Token handleAlternativeStringLiteral(PeekingReader reader, ParserContext context, int pos, int line, int col) throws IOException {
+        String alternativeQuoteOpen = ALTERNATIVE_QUOTE;
+        String alternativeQuoteEnd = ALTERNATIVE_QUOTE;
+
+        String text;
+
+        reader.swallow(alternativeQuoteOpen.length());
+        text = reader.readUntilExcluding(alternativeQuoteOpen, alternativeQuoteEnd);
+        reader.swallow(alternativeQuoteEnd.length());
+
+        return new Token(TokenType.STRING, pos, line, col, text, text, context.getParensDepth());
+    }
+
+    @Override
+    protected boolean isSingleLineComment(String peek, ParserContext context, int col) {
+        return peek.startsWith("--") || peek.startsWith("//");
     }
 }

--- a/flyway-database-timeplus/src/main/java/org/flywaydb/community/database/timeplus/TimeplusParser.java
+++ b/flyway-database-timeplus/src/main/java/org/flywaydb/community/database/timeplus/TimeplusParser.java
@@ -1,0 +1,45 @@
+/*-
+ * ========================LICENSE_START=================================
+ * flyway-database-timeplus
+ * ========================================================================
+ * Copyright (C) 2010 - 2024 Red Gate Software Ltd
+ * ========================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+/*
+ * Copyright (C) Red Gate Software Ltd 2010-2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.community.database.timeplus;
+
+import org.flywaydb.core.api.configuration.Configuration;
+import org.flywaydb.core.internal.parser.Parser;
+import org.flywaydb.core.internal.parser.ParsingContext;
+
+public class TimeplusParser extends Parser {
+    protected TimeplusParser(Configuration configuration, ParsingContext parsingContext, int peekDepth) {
+        super(configuration, parsingContext, peekDepth);
+    }
+}

--- a/flyway-database-timeplus/src/main/java/org/flywaydb/community/database/timeplus/TimeplusSchema.java
+++ b/flyway-database-timeplus/src/main/java/org/flywaydb/community/database/timeplus/TimeplusSchema.java
@@ -1,0 +1,109 @@
+/*-
+ * ========================LICENSE_START=================================
+ * flyway-database-timeplus
+ * ========================================================================
+ * Copyright (C) 2010 - 2024 Red Gate Software Ltd
+ * ========================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+/*
+ * Copyright (C) Red Gate Software Ltd 2010-2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.community.database.timeplus;
+
+import org.flywaydb.core.internal.database.base.Schema;
+import org.flywaydb.core.internal.jdbc.JdbcTemplate;
+import org.flywaydb.core.internal.util.StringUtils;
+
+import java.sql.SQLException;
+import java.util.Optional;
+
+public class TimeplusSchema extends Schema<TimeplusDatabase, TimeplusTable> {
+
+    private static final String DEFAULT_SCHEMA = "default";
+
+    /**
+     * @param jdbcTemplate The Jdbc Template for communicating with the DB.
+     * @param database The database-specific support.
+     * @param name The name of the schema.
+     */
+    public TimeplusSchema(JdbcTemplate jdbcTemplate, TimeplusDatabase database, String name) {
+        super(jdbcTemplate, database, name);
+    }
+
+    @Override
+    protected boolean doExists() throws SQLException {
+        TimeplusConnection systemConnection = database.getSystemConnection();
+        int i = systemConnection.getJdbcTemplate().queryForInt("SELECT COUNT() FROM system.databases WHERE name = ?", name);
+        return i > 0;
+    }
+
+    @Override
+    protected boolean doEmpty() throws SQLException {
+        TimeplusConnection systemConnection = database.getSystemConnection();
+        int i = systemConnection.getJdbcTemplate().queryForInt("SELECT COUNT() FROM system.tables WHERE database = ?", name);
+        return i == 0;
+    }
+
+    @Override
+    protected void doCreate() throws SQLException {
+        TimeplusConnection systemConnection = database.getSystemConnection();
+        String clusterName = database.getClusterName();
+        boolean isClustered = StringUtils.hasText(clusterName);
+        systemConnection.getJdbcTemplate().executeStatement("CREATE DATABASE " + database.quote(name) + (false&&isClustered ? (" ON CLUSTER " + clusterName) : ""));
+    }
+
+    @Override
+    protected void doDrop() throws SQLException {
+        if (database.getMainConnection().getCurrentSchemaNameOrSearchPath().equals(name)) {
+            database.getMainConnection().doChangeCurrentSchemaOrSearchPathTo(Optional.ofNullable(database.getConfiguration().getDefaultSchema()).orElse(DEFAULT_SCHEMA));
+        }
+        String clusterName = database.getClusterName();
+        boolean isClustered = StringUtils.hasText(clusterName);
+        jdbcTemplate.executeStatement("DROP DATABASE " + database.quote(name) + (isClustered ? (" ON CLUSTER " + clusterName) : ""));
+    }
+
+    @Override
+    protected void doClean() throws SQLException {
+        for (TimeplusTable table : allTables()) {
+            table.drop();
+        }
+    }
+
+    @Override
+    protected TimeplusTable[] doAllTables() throws SQLException {
+        TimeplusConnection systemConnection = database.getSystemConnection();
+        return systemConnection.getJdbcTemplate().queryForStringList("SELECT name FROM system.tables WHERE database = ?", name)
+                .stream()
+                .map(this::getTable)
+                .toArray(TimeplusTable[]::new);
+    }
+
+    @Override
+    public TimeplusTable getTable(String tableName) {
+        return new TimeplusTable(jdbcTemplate, database, this, tableName);
+    }
+}

--- a/flyway-database-timeplus/src/main/java/org/flywaydb/community/database/timeplus/TimeplusTable.java
+++ b/flyway-database-timeplus/src/main/java/org/flywaydb/community/database/timeplus/TimeplusTable.java
@@ -1,0 +1,74 @@
+/*-
+ * ========================LICENSE_START=================================
+ * flyway-database-timeplus
+ * ========================================================================
+ * Copyright (C) 2010 - 2024 Red Gate Software Ltd
+ * ========================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+/*
+ * Copyright (C) Red Gate Software Ltd 2010-2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.community.database.timeplus;
+
+import lombok.CustomLog;
+import org.flywaydb.core.internal.database.base.Table;
+import org.flywaydb.core.internal.jdbc.JdbcTemplate;
+import org.flywaydb.core.internal.util.StringUtils;
+
+import java.sql.SQLException;
+
+@CustomLog
+public class TimeplusTable extends Table<TimeplusDatabase, TimeplusSchema> {
+    /**
+     * @param jdbcTemplate The JDBC template for communicating with the DB.
+     * @param database The database-specific support.
+     * @param schema The schema this table lives in.
+     * @param name The name of the table.
+     */
+    public TimeplusTable(JdbcTemplate jdbcTemplate, TimeplusDatabase database, TimeplusSchema schema, String name) {
+        super(jdbcTemplate, database, schema, name);
+    }
+
+    @Override
+    protected void doDrop() throws SQLException {
+        String clusterName = database.getClusterName();
+
+        jdbcTemplate.executeStatement("DROP TABLE " + this + (StringUtils.hasText(clusterName) ? (" ON CLUSTER " + clusterName) : ""));
+    }
+
+    @Override
+    protected boolean doExists() throws SQLException {
+        TimeplusConnection systemConnection = database.getSystemConnection();
+        int count = systemConnection.getJdbcTemplate().queryForInt("SELECT COUNT() FROM system.tables WHERE database = ? AND name = ?", schema.getName(), name);
+        return count > 0;
+    }
+
+    @Override
+    protected void doLock() throws SQLException {
+        LOG.debug("Unable to lock " + this + " as Timeplus does not support locking. No concurrent migration supported.");
+    }
+}

--- a/flyway-database-timeplus/src/main/java/org/flywaydb/community/database/timeplus/TimeplusTable.java
+++ b/flyway-database-timeplus/src/main/java/org/flywaydb/community/database/timeplus/TimeplusTable.java
@@ -57,7 +57,7 @@ public class TimeplusTable extends Table<TimeplusDatabase, TimeplusSchema> {
     protected void doDrop() throws SQLException {
         String clusterName = database.getClusterName();
 
-        jdbcTemplate.executeStatement("DROP TABLE " + this + (StringUtils.hasText(clusterName) ? (" ON CLUSTER " + clusterName) : ""));
+        jdbcTemplate.executeStatement("DROP STREAM " + this + (StringUtils.hasText(clusterName) ? (" ON CLUSTER " + clusterName) : ""));
     }
 
     @Override

--- a/flyway-database-timeplus/src/main/resources/META-INF/services/org.flywaydb.core.extensibility.Plugin
+++ b/flyway-database-timeplus/src/main/resources/META-INF/services/org.flywaydb.core.extensibility.Plugin
@@ -1,0 +1,2 @@
+org.flywaydb.community.database.timeplus.TimeplusConfigurationExtension
+org.flywaydb.community.database.timeplus.TimeplusDatabaseType

--- a/flyway-database-timeplus/src/main/resources/org/flywaydb/community/database/timeplus/version.txt
+++ b/flyway-database-timeplus/src/main/resources/org/flywaydb/community/database/timeplus/version.txt
@@ -1,0 +1,1 @@
+${pom.version}

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,7 @@
         <module>flyway-database-databricks</module>
         <module>flyway-database-db2zos</module>
         <module>flyway-community-db-support-archetype</module>
+        <module>flyway-database-timeplus</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
Timeplus is a simple, powerful, and cost-efficient stream processing platform. This PR added support for both Timeplus Proton (https://github.com/timeplus-io/proton) and Timeplus Enterprise (https://timeplus.com/product). The plugin is tested with Timeplus Enterprise and verified with one of our customers who also purchased flyway.

To test it:

Start a docker instance of Timeplus Enterprise via 
```bash
docker run --name tpe2.5.11 -p 8000:8000 -p 8463:8463  -p 7587:7587 timeplus/timeplus-enterprise:2.5.11
```
Then you can access http://localhost:8000 and create the first user, say admin, with password `changeme`.

In the working folder, create flyway.toml
```toml
[environments.tplocal]
url = "jdbc:timeplus://localhost:7587"
user = "admin"
password = "changeme"
[flyway]
validateMigrationNaming = true
environment = "tplocal"
locations = ["filesystem:migrations"]
cleanDisabled = false
```
and create some SQL files in the migrations folder.

Download the JDBC jar from https://github.com/timeplus-io/timeplus-native-jdbc/releases/tag/v2.0.7 and put in lib folder.

-----

PS. the code is largely based on the ClickHouse database support, with necessary SQL keywords or data type names changes.