### PR TITLE
kingdb support

### DIFF
--- a/flyway-database-kingdb/pom.xml
+++ b/flyway-database-kingdb/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.flywaydb</groupId>
+        <artifactId>flyway-community-db-support</artifactId>
+        <version>10.16.3</version>
+    </parent>
+
+    <artifactId>flyway-database-kingdb</artifactId>
+
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>flyway-core</artifactId>
+            <version>${version.flyway}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>flyway-database-postgresql</artifactId>
+            <version>${version.flyway}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.flywaydb</groupId>
+                    <artifactId>flyway-core</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+</project>

--- a/flyway-database-kingdb/src/main/java/org/flywaydb/community/database/kingdb/KingDBConnection.java
+++ b/flyway-database-kingdb/src/main/java/org/flywaydb/community/database/kingdb/KingDBConnection.java
@@ -1,0 +1,35 @@
+/*-
+ * ========================LICENSE_START=================================
+ * flyway-database-kingdb
+ * ========================================================================
+ * Copyright (C) 2010 - 2025 Red Gate Software Ltd
+ * ========================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+package org.flywaydb.community.database.kingdb;
+
+import org.flywaydb.core.internal.database.base.Schema;
+import org.flywaydb.database.postgresql.PostgreSQLConnection;
+
+
+public class KingDBConnection extends PostgreSQLConnection {
+    protected KingDBConnection(KingDBDatabase database, java.sql.Connection connection) {
+        super(database, connection);
+    }
+
+    @Override
+    public Schema getSchema(String name) {
+        return new KingDBSchema(jdbcTemplate, database, name);
+    }
+}

--- a/flyway-database-kingdb/src/main/java/org/flywaydb/community/database/kingdb/KingDBDatabase.java
+++ b/flyway-database-kingdb/src/main/java/org/flywaydb/community/database/kingdb/KingDBDatabase.java
@@ -1,0 +1,58 @@
+/*-
+ * ========================LICENSE_START=================================
+ * flyway-database-kingdb
+ * ========================================================================
+ * Copyright (C) 2010 - 2025 Red Gate Software Ltd
+ * ========================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+package org.flywaydb.community.database.kingdb;
+
+import org.flywaydb.core.api.configuration.Configuration;
+import org.flywaydb.core.internal.database.base.Table;
+import org.flywaydb.database.postgresql.PostgreSQLDatabase;
+import org.flywaydb.core.internal.jdbc.JdbcConnectionFactory;
+import org.flywaydb.core.internal.jdbc.StatementInterceptor;
+
+import java.sql.Connection;
+
+public class KingDBDatabase extends PostgreSQLDatabase {
+
+    public KingDBDatabase(Configuration configuration, JdbcConnectionFactory jdbcConnectionFactory, StatementInterceptor statementInterceptor) {
+        super(configuration, jdbcConnectionFactory, statementInterceptor);
+    }
+
+    @Override
+    protected KingDBConnection doGetConnection(Connection connection) {
+        return new KingDBConnection(this, connection);
+    }
+
+    @Override
+    public String getRawCreateScript(Table table, boolean baseline) {
+        return "CREATE TABLE IF NOT EXISTS " + table + " (\n" +
+                "    \"installed_rank\" INT NOT NULL PRIMARY KEY,\n" +
+                "    \"version\" VARCHAR(50),\n" +
+                "    \"description\" VARCHAR(200) NOT NULL,\n" +
+                "    \"type\" VARCHAR(20) NOT NULL,\n" +
+                "    \"script\" VARCHAR(1000) NOT NULL,\n" +
+                "    \"checksum\" INTEGER,\n" +
+                "    \"installed_by\" VARCHAR(100) NOT NULL,\n" +
+                "    \"installed_on\" TIMESTAMP NOT NULL DEFAULT now(),\n" +
+                "    \"execution_time\" INTEGER NOT NULL,\n" +
+                "    \"success\" BOOLEAN NOT NULL\n" +
+                ");\n" +
+                (baseline ? getBaselineStatement(table) + ";\n" : "") +
+                "CREATE INDEX IF NOT EXISTS \"" + table.getName() + "_s_idx\" ON " + table + " (\"success\");";
+    }
+}

--- a/flyway-database-kingdb/src/main/java/org/flywaydb/community/database/kingdb/KingDBDatabaseType.java
+++ b/flyway-database-kingdb/src/main/java/org/flywaydb/community/database/kingdb/KingDBDatabaseType.java
@@ -1,0 +1,67 @@
+/*-
+ * ========================LICENSE_START=================================
+ * flyway-database-kingdb
+ * ========================================================================
+ * Copyright (C) 2010 - 2025 Red Gate Software Ltd
+ * ========================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+package org.flywaydb.community.database.kingdb;
+
+import org.flywaydb.core.api.ResourceProvider;
+import org.flywaydb.core.api.configuration.Configuration;
+
+import org.flywaydb.core.internal.database.base.CommunityDatabaseType;
+import org.flywaydb.core.internal.database.base.Database;
+import org.flywaydb.core.internal.jdbc.JdbcConnectionFactory;
+import org.flywaydb.core.internal.jdbc.StatementInterceptor;
+import org.flywaydb.core.internal.parser.Parser;
+import org.flywaydb.core.internal.parser.ParsingContext;
+import org.flywaydb.database.postgresql.PostgreSQLDatabaseType;
+
+import java.sql.Connection;
+
+
+public class KingDBDatabaseType extends PostgreSQLDatabaseType implements CommunityDatabaseType {
+
+    @Override
+    public String getName() {
+        return "KingDB";
+    }
+
+    @Override
+    public boolean handlesJDBCUrl(String url) {
+        return url.startsWith("jdbc:kingbase8:") ;
+    }
+
+    @Override
+    public String getDriverClass(String url, ClassLoader classLoader) {
+        return url.startsWith("jdbc:kingbase8:") ? "com.kingbase8.Driver" : super.getDriverClass(url, classLoader);
+    }
+
+    @Override
+    public boolean handlesDatabaseProductNameAndVersion(String databaseProductName, String databaseProductVersion, Connection connection) {
+        return databaseProductName.toLowerCase().startsWith("kingbase");
+    }
+
+    @Override
+    public Database createDatabase(Configuration configuration, JdbcConnectionFactory jdbcConnectionFactory, StatementInterceptor statementInterceptor) {
+        return new KingDBDatabase(configuration, jdbcConnectionFactory, statementInterceptor);
+    }
+
+    @Override
+    public Parser createParser(Configuration configuration, ResourceProvider resourceProvider, ParsingContext parsingContext) {
+        return  new KingDBParser(configuration, parsingContext);
+    }
+}

--- a/flyway-database-kingdb/src/main/java/org/flywaydb/community/database/kingdb/KingDBParser.java
+++ b/flyway-database-kingdb/src/main/java/org/flywaydb/community/database/kingdb/KingDBParser.java
@@ -1,0 +1,32 @@
+/*-
+ * ========================LICENSE_START=================================
+ * flyway-database-kingdb
+ * ========================================================================
+ * Copyright (C) 2010 - 2025 Red Gate Software Ltd
+ * ========================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+package org.flywaydb.community.database.kingdb;
+
+import org.flywaydb.core.api.configuration.Configuration;
+import org.flywaydb.core.internal.parser.Parser;
+import org.flywaydb.core.internal.parser.ParsingContext;
+import org.flywaydb.database.postgresql.PostgreSQLParser;
+
+public class KingDBParser extends PostgreSQLParser {
+
+    public KingDBParser(Configuration configuration, ParsingContext parsingContext) {
+        super(configuration, parsingContext);
+    }
+}

--- a/flyway-database-kingdb/src/main/java/org/flywaydb/community/database/kingdb/KingDBSchema.java
+++ b/flyway-database-kingdb/src/main/java/org/flywaydb/community/database/kingdb/KingDBSchema.java
@@ -1,0 +1,45 @@
+/*-
+ * ========================LICENSE_START=================================
+ * flyway-database-kingdb
+ * ========================================================================
+ * Copyright (C) 2010 - 2025 Red Gate Software Ltd
+ * ========================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+package org.flywaydb.community.database.kingdb;
+
+import org.flywaydb.core.internal.database.base.Table;
+import org.flywaydb.core.internal.jdbc.JdbcTemplate;
+import org.flywaydb.database.postgresql.PostgreSQLDatabase;
+import org.flywaydb.database.postgresql.PostgreSQLSchema;
+
+
+public class KingDBSchema extends PostgreSQLSchema {
+
+    /**
+     * Creates a new KingDBSchema schema.
+     *
+     * @param jdbcTemplate The Jdbc Template for communicating with the DB.
+     * @param database     The database-specific support.
+     * @param name         The name of the schema.
+     */
+    protected KingDBSchema(JdbcTemplate jdbcTemplate, PostgreSQLDatabase database, String name) {
+        super(jdbcTemplate, database, name);
+    }
+
+    @Override
+    public Table getTable(String tableName) {
+        return new KingDBTable(jdbcTemplate, (KingDBDatabase) database, this, tableName);
+    }
+}

--- a/flyway-database-kingdb/src/main/java/org/flywaydb/community/database/kingdb/KingDBTable.java
+++ b/flyway-database-kingdb/src/main/java/org/flywaydb/community/database/kingdb/KingDBTable.java
@@ -1,0 +1,41 @@
+/*-
+ * ========================LICENSE_START=================================
+ * flyway-database-kingdb
+ * ========================================================================
+ * Copyright (C) 2010 - 2025 Red Gate Software Ltd
+ * ========================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+package org.flywaydb.community.database.kingdb;
+
+import org.flywaydb.core.internal.jdbc.JdbcTemplate;
+import org.flywaydb.database.postgresql.PostgreSQLDatabase;
+import org.flywaydb.database.postgresql.PostgreSQLSchema;
+import org.flywaydb.database.postgresql.PostgreSQLTable;
+
+
+public class KingDBTable extends PostgreSQLTable {
+
+    /**
+     * Creates a new KingDBTable table.
+     *
+     * @param jdbcTemplate The Jdbc Template for communicating with the DB.
+     * @param database     The database-specific support.
+     * @param schema       The schema this table lives in.
+     * @param name         The name of the table.
+     */
+    protected KingDBTable(JdbcTemplate jdbcTemplate, PostgreSQLDatabase database, PostgreSQLSchema schema, String name) {
+        super(jdbcTemplate, database, schema, name);
+    }
+}

--- a/flyway-database-kingdb/src/main/java/org/flywaydb/community/database/kingdb/org/flywaydb/community/database/KingDBDatabaseExtension.java
+++ b/flyway-database-kingdb/src/main/java/org/flywaydb/community/database/kingdb/org/flywaydb/community/database/KingDBDatabaseExtension.java
@@ -1,0 +1,42 @@
+/*-
+ * ========================LICENSE_START=================================
+ * flyway-database-kingdb
+ * ========================================================================
+ * Copyright (C) 2010 - 2025 Red Gate Software Ltd
+ * ========================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+package org.flywaydb.community.database.kingdb.org.flywaydb.community.database;
+
+import org.flywaydb.core.api.FlywayException;
+import org.flywaydb.core.internal.util.FileUtils;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+public class KingDBDatabaseExtension {
+    public String getDescription() {
+        return "Community-contributed KingDB database support extension " + readVersion() + " by Redgate";
+    }
+
+    public static String readVersion() {
+        try {
+            return FileUtils.copyToString(
+                    KingDBDatabaseExtension.class.getClassLoader().getResourceAsStream("org/flywaydb/community/database/kingdb/version.txt"),
+                    StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new FlywayException("Unable to read extension version: " + e.getMessage(), e);
+        }
+    }
+}

--- a/flyway-database-kingdb/src/main/java/org/flywaydb/community/database/kingdb/package-info.java
+++ b/flyway-database-kingdb/src/main/java/org/flywaydb/community/database/kingdb/package-info.java
@@ -1,0 +1,23 @@
+/*-
+ * ========================LICENSE_START=================================
+ * flyway-database-kingdb
+ * ========================================================================
+ * Copyright (C) 2010 - 2025 Red Gate Software Ltd
+ * ========================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+/**
+ * Community-supported package. No compatibility guarantees provided.
+ */
+package org.flywaydb.community.database.kingdb;

--- a/flyway-database-kingdb/src/main/resources/META-INF/services/org.flywaydb.core.extensibility.Plugin
+++ b/flyway-database-kingdb/src/main/resources/META-INF/services/org.flywaydb.core.extensibility.Plugin
@@ -1,0 +1,1 @@
+org.flywaydb.community.database.kingdb.KingDBDatabaseType

--- a/flyway-database-kingdb/src/main/resources/org/flywaydb/community/database/kingdb/version.txt
+++ b/flyway-database-kingdb/src/main/resources/org/flywaydb/community/database/kingdb/version.txt
@@ -1,0 +1,1 @@
+${pom.version}

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,4 @@
-<!--
+<?xml version="1.0" encoding="UTF-8"?><!--
 
     Copyright (C) Red Gate Software Ltd 2010-2024
 
@@ -14,98 +14,91 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 
--->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <parent>
-        <groupId>org.flywaydb</groupId>
-        <artifactId>flyway-parent</artifactId>
-        <version>10.18.1</version>
-        <relativePath/>
-    </parent>
-    <modelVersion>4.0.0</modelVersion>
-
-    <artifactId>flyway-community-db-support</artifactId>
-    <packaging>pom</packaging>
-    <version>10.16.3</version>
-    <name>${project.artifactId}</name>
-
-    <modules>
-        <module>flyway-database-tidb</module>
-        <module>flyway-database-ignite</module>
-        <module>flyway-database-yugabytedb</module>
-        <module>flyway-database-clickhouse</module>
-        <module>flyway-database-oceanbase</module>
-        <module>flyway-database-databricks</module>
-        <module>flyway-database-db2zos</module>
-        <module>flyway-community-db-support-archetype</module>
-    </modules>
-
-    <properties>
-        <version.flyway>10.19.0</version.flyway>
-    </properties>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${project.groupId}</groupId>
-                <artifactId>flyway-core</artifactId>
-                <version>${version.flyway}</version>
-                <scope>provided</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
-    <build>
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <groupId>org.jacoco</groupId>
-                    <artifactId>jacoco-maven-plugin</artifactId>
-                    <version>0.8.10</version>
-                    <configuration>
-                        <skip>true</skip>
-                    </configuration>
-                </plugin>
-                <plugin>
-                    <artifactId>maven-resources-plugin</artifactId>
-                    <executions>
-                        <execution>
-                            <id>copy-license</id>
-                            <goals>
-                                <goal>copy-resources</goal>
-                            </goals>
-                            <phase>generate-resources</phase>
-                            <configuration>
-                                <resources>
-                                    <resource>
-                                        <directory>..</directory>
-                                        <includes>
-                                            <include>LICENSE.txt</include>
-                                            <include>README.txt</include>
-                                        </includes>
-                                    </resource>
-                                </resources>
-                                <outputDirectory>${project.build.outputDirectory}/META-INF</outputDirectory>
-                            </configuration>
-                        </execution>
-                    </executions>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.felix</groupId>
-                    <artifactId>maven-bundle-plugin</artifactId>
-                    <executions>
-                        <execution>
-                            <id>bundle-manifest</id>
-                            <phase>process-classes</phase>
-                            <goals>
-                                <goal>manifest</goal>
-                            </goals>
-                        </execution>
-                    </executions>
-                </plugin>
-            </plugins>
-        </pluginManagement>
-    </build>
+--><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>org.flywaydb</groupId>
+    <artifactId>flyway-parent</artifactId>
+    <version>10.18.1</version>
+    <relativePath/>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>flyway-community-db-support</artifactId>
+  <packaging>pom</packaging>
+  <version>10.16.3</version>
+  <name>${project.artifactId}</name>
+  <modules>
+    <module>flyway-database-tidb</module>
+    <module>flyway-database-ignite</module>
+    <module>flyway-database-yugabytedb</module>
+    <module>flyway-database-clickhouse</module>
+    <module>flyway-database-oceanbase</module>
+    <module>flyway-database-databricks</module>
+    <module>flyway-database-db2zos</module>
+    <module>flyway-community-db-support-archetype</module>
+      <module>flyway-database-kingdb</module>
+  </modules>
+  <properties>
+    <version.flyway>10.19.0</version.flyway>
+  </properties>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>${project.groupId}</groupId>
+        <artifactId>flyway-core</artifactId>
+        <version>${version.flyway}</version>
+        <scope>provided</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.jacoco</groupId>
+          <artifactId>jacoco-maven-plugin</artifactId>
+          <version>0.8.10</version>
+          <configuration>
+            <skip>true</skip>
+          </configuration>
+        </plugin>
+        <plugin>
+          <artifactId>maven-resources-plugin</artifactId>
+          <executions>
+            <execution>
+              <id>copy-license</id>
+              <goals>
+                <goal>copy-resources</goal>
+              </goals>
+              <phase>generate-resources</phase>
+              <configuration>
+                <resources>
+                  <resource>
+                    <directory>..</directory>
+                    <includes>
+                      <include>LICENSE.txt</include>
+                      <include>README.txt</include>
+                    </includes>
+                  </resource>
+                </resources>
+                <outputDirectory>${project.build.outputDirectory}/META-INF</outputDirectory>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.felix</groupId>
+          <artifactId>maven-bundle-plugin</artifactId>
+          <executions>
+            <execution>
+              <id>bundle-manifest</id>
+              <phase>process-classes</phase>
+              <goals>
+                <goal>manifest</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
 </project>


### PR DESCRIPTION
### Change Description
This pr adds support to Kingbase database v8, which is widely used in China. Kingbase is based on PostgreSQL , hence many classes in the plugin extends PostgreSQL.

### Tests
The test is done against kingbase v8 `KingbaseES V008R006C009B0014 on x86_64-pc-linux-gnu, compiled by gcc (GCC) 4.8.5 20150623 (Red Hat 4.8.5-28), 64-bit`.

Here's the history table after running `flyway baseline` and `flyway migrate`
![7dc5ee62-7cf6-41c8-8990-76cd8a010e00](https://github.com/user-attachments/assets/f8a9d3a3-ce7b-461e-ab6c-982561bd2fba)

The plugin is being used in our internal kingbase  and java applications.

### Notes to use kingbase plugin
Configruation example

```text
user=system
password=password
url=jdbc:kingbase8://192.168.1.1:54321/test_db
driver=com.kingbase8.Driver
```

Kingbase jdbc maven coordinates
```text
<dependency>
    <groupId>cn.com.kingbase</groupId>
    <artifactId>kingbase8</artifactId>
    <version>8.6.0</version>
</dependency>
```

Please review,  I'm looking forward to feedbacks.