### PR TITLE
Fix `clean` for duckdb when FKs exist. #80

### DIFF
--- a/flyway-database-duckdb/pom.xml
+++ b/flyway-database-duckdb/pom.xml
@@ -55,7 +55,7 @@
         <dependency>
             <groupId>org.duckdb</groupId>
             <artifactId>duckdb_jdbc</artifactId>
-            <version>1.0.0</version>
+            <version>1.2.2.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/flyway-database-duckdb/src/test/java/org/flywaydb/community/database/duckdb/DuckDBSupportTest.java
+++ b/flyway-database-duckdb/src/test/java/org/flywaydb/community/database/duckdb/DuckDBSupportTest.java
@@ -28,6 +28,7 @@ import java.io.File;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.util.List;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -63,7 +64,7 @@ class DuckDBSupportTest {
         flyway.migrate();
 
         // then
-        assertThat(getAllTablesNames("main")).isEqualTo(List.of("flyway_schema_history", "some_table"));
+        assertThat(getAllTablesNames("main")).isEqualTo(Set.of("flyway_schema_history", "some_table", "some_table_2", "some_table_3"));
         assertThat(getFlywayHistoryMigrationDescriptions()).isEqualTo(List.of("first", "second"));
         assertThat(getAllViewsNames()).contains("some_view");
         assertThat(getAllMacrosNames()).contains("some_is_empty");
@@ -128,7 +129,8 @@ class DuckDBSupportTest {
 
         // then
         assertThat(getAllTablesNames("main")).isEmpty();
-        assertThat(getAllTablesNames("some_schema")).isEqualTo(List.of("flyway_schema_history", "some_table"));
+        assertThat(getAllTablesNames("some_schema")).isEqualTo(Set.of("flyway_schema_history", "some_table", "some_table_2", "some_table_3"));
+        assertThat(getAllTablesNames("some_schema")).isEqualTo(Set.of("flyway_schema_history", "some_table", "some_table_2", "some_table_3"));
     }
 
     @Test
@@ -146,7 +148,7 @@ class DuckDBSupportTest {
         flyway.baseline();
 
         // then
-        assertThat(getAllTablesNames("main")).isEqualTo(List.of("flyway_schema_history"));
+        assertThat(getAllTablesNames("main")).isEqualTo(Set.of("flyway_schema_history"));
         assertThat(getFlywayHistoryMigrationDescriptions()).isEqualTo(List.of("<< Flyway Baseline >>"));
     }
 
@@ -163,7 +165,7 @@ class DuckDBSupportTest {
         final var systemMacros = getAllMacrosNames();
 
         flyway.migrate();
-        assertThat(getAllTablesNames("main")).isEqualTo(List.of("flyway_schema_history", "some_table"));
+        assertThat(getAllTablesNames("main")).isEqualTo(Set.of("flyway_schema_history", "some_table", "some_table_2", "some_table_3"));
         assertThat(getAllViewsNames().size()).isGreaterThan(systemViews.size());
         assertThat(getAllMacrosNames().size()).isGreaterThan(systemMacros.size());
         assertThat(getAllSequencesNames()).isEqualTo(List.of("some_sequence"));
@@ -178,8 +180,8 @@ class DuckDBSupportTest {
         assertThat(getAllSequencesNames()).isEmpty();
     }
 
-    private List<String> getAllTablesNames(String schema) throws SQLException {
-        return jdbcTemplate.queryForStringList("SELECT table_name FROM duckdb_tables() WHERE schema_name = ?", schema);
+    private Set<String> getAllTablesNames(String schema) throws SQLException {
+        return Set.copyOf(jdbcTemplate.queryForStringList("SELECT table_name FROM duckdb_tables() WHERE schema_name = ?", schema));
     }
 
     private List<String> getAllViewsNames() throws SQLException {

--- a/flyway-database-duckdb/src/test/resources/initial_migration/V001__first.sql
+++ b/flyway-database-duckdb/src/test/resources/initial_migration/V001__first.sql
@@ -18,11 +18,23 @@
 -- =========================LICENSE_END==================================
 ---
 CREATE TABLE ${flyway:defaultSchema}.some_table(
-    id INT,
+    id INT PRIMARY KEY,
     text VARCHAR
 );
 
 CREATE INDEX some_table_text ON ${flyway:defaultSchema}.some_table(text);
+
+-- a table with a foreign key referencing `some_table`, which makes `some_table` and edge case for drop table
+CREATE TABLE ${flyway:defaultSchema}.some_table_2(
+    id INT PRIMARY KEY,
+    some_table_id INT REFERENCES ${flyway:defaultSchema}.some_table(id)
+);
+
+-- a table with a foreign key referencing itself, which makes it an edge case for drop table
+CREATE TABLE ${flyway:defaultSchema}.some_table_3(
+    id INT PRIMARY KEY,
+    some_table_id INT REFERENCES ${flyway:defaultSchema}.some_table_3(id)
+);
 
 CREATE SEQUENCE some_sequence;
 

--- a/flyway-database-duckdb/src/test/resources/next_migration/V001__first.sql
+++ b/flyway-database-duckdb/src/test/resources/next_migration/V001__first.sql
@@ -18,11 +18,23 @@
 -- =========================LICENSE_END==================================
 ---
 CREATE TABLE ${flyway:defaultSchema}.some_table(
-    id INT,
+    id INT PRIMARY KEY,
     text VARCHAR
 );
 
 CREATE INDEX some_table_text ON ${flyway:defaultSchema}.some_table(text);
+
+-- a table with a foreign key referencing `some_table`, which makes `some_table` and edge case for drop table
+CREATE TABLE ${flyway:defaultSchema}.some_table_2(
+    id INT PRIMARY KEY,
+    some_table_id INT REFERENCES ${flyway:defaultSchema}.some_table(id)
+);
+
+-- a table with a foreign key referencing itself, which makes it an edge case for drop table
+CREATE TABLE ${flyway:defaultSchema}.some_table_3(
+    id INT PRIMARY KEY,
+    some_table_id INT REFERENCES ${flyway:defaultSchema}.some_table_3(id)
+);
 
 CREATE SEQUENCE some_sequence;
 


### PR DESCRIPTION
duckdb does not support cascade drop table. This fix is to iterate through the tables and delete the ones without incoming references first.