### PR TITLE
Fix #111: Filter lock table check by current_schema() for multi-schem…

### DIFF
--- a/flyway-database-yugabytedb/src/main/java/org/flywaydb/community/database/postgresql/yugabytedb/YugabyteDBDatabase.java
+++ b/flyway-database-yugabytedb/src/main/java/org/flywaydb/community/database/postgresql/yugabytedb/YugabyteDBDatabase.java
@@ -38,7 +38,8 @@ public class YugabyteDBDatabase extends PostgreSQLDatabase {
 
     public static final String LOCK_TABLE_NAME = "YB_FLYWAY_LOCK_TABLE";
     // Using table name in lower case, see https://github.com/flyway/flyway-community-db-support/issues/97
-    private static final String LOCK_TABLE_SCHEMA_SQL = "SELECT table_name, column_name FROM information_schema.columns WHERE table_name = '" + LOCK_TABLE_NAME.toLowerCase() + "'";
+    // Filter by current schema to support multi-schema migrations
+    private static final String LOCK_TABLE_SCHEMA_SQL = "SELECT table_name, column_name FROM information_schema.columns WHERE table_name = '" + LOCK_TABLE_NAME.toLowerCase() + "' AND table_schema = current_schema()";
     private static final String DROP_LOCK_TABLE_IF_EXISTS_DDL = "DROP TABLE IF EXISTS " + LOCK_TABLE_NAME;
     /**
      * This table is used to enforce locking through SELECT ... FOR UPDATE on a


### PR DESCRIPTION
…a support

The YugabyteDB extension was checking for the existence of yb_flyway_lock_table across ALL schemas using information_schema.columns without filtering by schema. This caused issues when migrating multiple schemas:
- First schema creates the lock table successfully
- Subsequent schemas find the table exists (in another schema) and don't create their own
- When trying to use the lock table, it fails because it's not in the current schema

This fix adds 'AND table_schema = current_schema()' to the LOCK_TABLE_SCHEMA_SQL query, ensuring each schema checks for and creates its own independent lock table.

Fixes #111