### PR TITLE
Fix #115: Wrap ClickHouse cluster name in quotes

### DIFF
--- a/flyway-database-clickhouse/src/main/java/org/flywaydb/community/database/clickhouse/ClickHouseDatabase.java
+++ b/flyway-database-clickhouse/src/main/java/org/flywaydb/community/database/clickhouse/ClickHouseDatabase.java
@@ -119,7 +119,7 @@ public class ClickHouseDatabase extends Database<ClickHouseConnection> {
         String clusterName = getClusterName();
         boolean isClustered = StringUtils.hasText(clusterName);
 
-        String script = "CREATE TABLE IF NOT EXISTS " + table + (isClustered ? (" ON CLUSTER " + clusterName) : "") + "(" +
+        String script = "CREATE TABLE IF NOT EXISTS " + table + (isClustered ? (" ON CLUSTER '" + clusterName + "'") : "") + "(" +
                 "    installed_rank Int32," +
                 "    version Nullable(String)," +
                 "    description String," +


### PR DESCRIPTION
The cluster name parameter in the ON CLUSTER clause is now wrapped in single quotes to support cluster names with special characters (like underscores) and to allow the use of the {cluster} macro.