### PR TITLE
Handle Databricks block depth

### DIFF
--- a/flyway-database-databricks/src/main/java/org/flywaydb/community/database/databricks/DatabricksParser.java
+++ b/flyway-database-databricks/src/main/java/org/flywaydb/community/database/databricks/DatabricksParser.java
@@ -39,7 +39,7 @@ public class DatabricksParser extends Parser {
             "VOLUME"
     );
 
-    protected DatabricksParser(Configuration configuration, ParsingContext parsingContext) {
+    public DatabricksParser(Configuration configuration, ParsingContext parsingContext) {
         super(configuration, parsingContext, 3);
     }
 

--- a/flyway-database-databricks/src/main/java/org/flywaydb/community/database/databricks/DatabricksParser.java
+++ b/flyway-database-databricks/src/main/java/org/flywaydb/community/database/databricks/DatabricksParser.java
@@ -20,11 +20,59 @@
 package org.flywaydb.community.database.databricks;
 
 import org.flywaydb.core.api.configuration.Configuration;
-import org.flywaydb.core.internal.parser.Parser;
-import org.flywaydb.core.internal.parser.ParsingContext;
+import org.flywaydb.core.internal.parser.*;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
 
 public class DatabricksParser extends Parser {
+    private static final List<String> CONDITIONALLY_CREATABLE_OBJECTS = Arrays.asList(
+            "CATALOG",
+            "CONNECTION",
+            "DATABASE",
+            "FUNCTION",
+            "SCHEMA",
+            "TABLE",
+            "VIEW",
+            "VOLUME"
+    );
+
     protected DatabricksParser(Configuration configuration, ParsingContext parsingContext) {
         super(configuration, parsingContext, 3);
+    }
+
+    @Override
+    protected void adjustBlockDepth(final ParserContext context,
+                                    final List<Token> tokens,
+                                    final Token keyword,
+                                    final PeekingReader reader
+    ) throws IOException {
+        int lastKeywordIndex = getLastKeywordIndex(tokens);
+        final Token previousKeyword = lastKeywordIndex >= 0 ? tokens.get(lastKeywordIndex) : null;
+        String keywordText = keyword.getText();
+        String previousKeywordText = previousKeyword != null ? previousKeyword.getText().toUpperCase(Locale.ENGLISH) : "";
+
+        if ("BEGIN".equalsIgnoreCase(keywordText)
+                && (reader.peekIgnoreCase(" TRANSACTION") || reader.peekIgnoreCase(" WORK"))) {
+            return;
+        }
+
+        if ("BEGIN".equalsIgnoreCase(keywordText)
+                || (("CASE".equalsIgnoreCase(keywordText)
+                    || ("IF".equalsIgnoreCase(keywordText)
+                        && !CONDITIONALLY_CREATABLE_OBJECTS.contains(previousKeywordText))
+                    || "FOR".equalsIgnoreCase(keywordText)
+                    || "WHILE".equalsIgnoreCase(keywordText)
+                    || "LOOP".equalsIgnoreCase(keywordText)
+                    || "REPEAT".equalsIgnoreCase(keywordText))
+                    && previousKeyword != null
+                    && !(lastKeywordIndex == tokens.size() - 1 && "END".equalsIgnoreCase(previousKeywordText))
+                    && !"CURSOR".equalsIgnoreCase(previousKeywordText))) {
+            context.increaseBlockDepth(keywordText);
+        } else if ("END".equalsIgnoreCase(keywordText) && context.getBlockDepth() > 0) {
+            context.decreaseBlockDepth();
+        }
     }
 }


### PR DESCRIPTION
Handles block depth for the Databricks parser to prevent early splitting in nested blocks e.g. this snippet would split on the first `END;` prior to the change.
```sql
CREATE OR REPLACE PROCEDURE default.test_update_proc(
    run_id INT
)
LANGUAGE SQL
SQL SECURITY INVOKER
AS
BEGIN
MERGE INTO default.test_target t
    USING (
        SELECT
            s.id,
            s.name,
            s.value
        FROM default.test_source s
    ) src
    ON t.id = src.id

    WHEN MATCHED THEN UPDATE SET
        t.value = src.value,
        t.updated_by = CASE
                           WHEN run_id < 0 THEN 'manual'
                           ELSE t.updated_by
            END,
        t.updated_on = CASE
                           WHEN run_id < 0 THEN current_timestamp()
                           ELSE t.updated_on
            END;
END;
```