### PR TITLE
Pin QuestDB docker image to 9.3.5

### DIFF
--- a/flyway-database-questdb/src/test/java/org/flywaydb/community/database/questdb/QuestDBTest.java
+++ b/flyway-database-questdb/src/test/java/org/flywaydb/community/database/questdb/QuestDBTest.java
@@ -32,7 +32,7 @@ import static org.junit.Assert.*;
 
 public class QuestDBTest {
     private static final DockerImageName QUESTDB_IMAGE = DockerImageName.parse("questdb/questdb:9.3.5");
-    private static final long ASSERT_QUERY_TIMEOUT = 10000L;
+    private static final long ASSERT_QUERY_TIMEOUT = 30000L;
     private static final int HTTP_PORT = 9000;
     private static final int PG_PORT = 8812;
     private static final String LOCATION = "questdb_migration";

--- a/flyway-database-questdb/src/test/java/org/flywaydb/community/database/questdb/QuestDBTest.java
+++ b/flyway-database-questdb/src/test/java/org/flywaydb/community/database/questdb/QuestDBTest.java
@@ -31,7 +31,7 @@ import java.sql.*;
 import static org.junit.Assert.*;
 
 public class QuestDBTest {
-    private static final DockerImageName QUESTDB_IMAGE = DockerImageName.parse("questdb/questdb:nightly");
+    private static final DockerImageName QUESTDB_IMAGE = DockerImageName.parse("questdb/questdb:9.3.5");
     private static final long ASSERT_QUERY_TIMEOUT = 10000L;
     private static final int HTTP_PORT = 9000;
     private static final int PG_PORT = 8812;


### PR DESCRIPTION
The QuestDB nightly docker image rebuilds daily and changes output formats frequently failing our tests. Pins the version to 9.3.5 for stability.