### PR TITLE
Unset git token from checkout step

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -60,6 +60,7 @@ jobs:
       - name: Bump versions
         if: github.ref == 'refs/heads/main'
         run: |
+          git config --unset-all http.https://github.com/.extraheader
           git remote set-url origin https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/flyway/flyway-community-db-support.git
 
           LATEST_TAG=$(git describe --tags $(git rev-list --tags --max-count=1) 2>/dev/null || echo "")


### PR DESCRIPTION
Using `checkout@v4` and `git remote set-url` will create two separate auth mechanisms. Checkout sets a `http.extraheader` git config which apparently takes precedency here.