### PR TITLE
Bump Maven archetype

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -85,6 +85,7 @@ jobs:
 
           echo "Bumping version: $CURRENT_VERSION -> $NEW_VERSION"
           mvn versions:set -DnewVersion=$NEW_VERSION
+          mvn versions:set -DnewVersion=$NEW_VERSION -pl flyway-community-db-support-archetype
 
           git add '*pom.xml'
           git commit -m "Bump Flyway Community DB Support to $NEW_VERSION"


### PR DESCRIPTION
Workflow fails on main because of a collision as it's stuck on 10.24.0 – we don't currently bump the Maven archetype.