### PR TITLE
[CUBRID] Drop foreign keys before clean

### DIFF
--- a/flyway-database-cubrid/src/main/java/org/flywaydb/community/database/cubrid/CubridSchema.java
+++ b/flyway-database-cubrid/src/main/java/org/flywaydb/community/database/cubrid/CubridSchema.java
@@ -19,6 +19,7 @@
  */
 package org.flywaydb.community.database.cubrid;
 
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import org.flywaydb.core.internal.database.base.Schema;
 import org.flywaydb.core.internal.jdbc.JdbcTemplate;
@@ -60,8 +61,23 @@ public class CubridSchema extends Schema<CubridDatabase, CubridTable> {
 
     @Override
     protected void doClean() throws SQLException {
+        dropForeignKeys();
+
         for (CubridTable table : doAllTables()) {
             table.doDrop();
+        }
+    }
+
+    private void dropForeignKeys() throws SQLException {
+        for (CubridTable table : doAllTables()) {
+            try (ResultSet resultSet = database.getJdbcMetaData().getImportedKeys(null, name, table.getName())) {
+                while (resultSet.next()) {
+                    String foreignKeyName = resultSet.getString("FK_NAME");
+                    String foreignKeyTableName = resultSet.getString("FKTABLE_NAME");
+                    jdbcTemplate.execute("ALTER TABLE " + database.quote(foreignKeyTableName)
+                        + " DROP CONSTRAINT " + database.quote(foreignKeyName));
+                }
+            }
         }
     }
 

--- a/flyway-database-cubrid/src/test/java/org/flywaydb/community/database/cubrid/CubridSupportTest.java
+++ b/flyway-database-cubrid/src/test/java/org/flywaydb/community/database/cubrid/CubridSupportTest.java
@@ -147,6 +147,37 @@ class CubridSupportTest {
         assertThat(tableNames()).doesNotContain("app_user", "flyway_schema_history");
     }
 
+    @Test
+    void cleansTablesWithForeignKeys() throws SQLException {
+        Flyway flyway = Flyway.configure()
+            .communityDBSupportEnabled(true)
+            .dataSource(jdbcUrl(), USER_SCHEMA, "")
+            .defaultSchema(USER_SCHEMA)
+            .cleanDisabled(false)
+            .load();
+
+        try {
+            try (Connection connection = connection();
+                 Statement statement = connection.createStatement()) {
+                statement.execute("CREATE TABLE parent_table (id INT PRIMARY KEY)");
+                statement.execute("CREATE TABLE child_table (id INT PRIMARY KEY, parent_id INT, "
+                    + "CONSTRAINT fk_child_parent FOREIGN KEY (parent_id) REFERENCES parent_table(id))");
+            }
+
+            assertThat(tableNames()).contains("parent_table", "child_table");
+
+            flyway.clean();
+
+            assertThat(tableNames()).doesNotContain("parent_table", "child_table");
+        } finally {
+            try (Connection connection = connection();
+                 Statement statement = connection.createStatement()) {
+                statement.execute("DROP TABLE IF EXISTS child_table");
+                statement.execute("DROP TABLE IF EXISTS parent_table");
+            }
+        }
+    }
+
     private static Flyway flyway(String... locations) {
         return Flyway.configure()
             .communityDBSupportEnabled(true)


### PR DESCRIPTION
## Summary
Flyway `clean` fails on CUBRID schemas containing tables linked by foreign keys. CUBRID prevents dropping a table that is still referenced by a foreign key from another table, so the current `CubridSchema.doClean()` fails when a parent table is encountered before its referecing children, and cannot resolve circular foreign key references at all.

This PR fixes ths issue by discovering incoming foreign keys via JDBC metadata and dropping those constraints before dropping the tables.

## Details
- `CubridSchema.doClean()` now calls `dropForeignKeys()` before iterating over `doAllTables()`.
- `dropForeignKeys()` queries `DatabaseMetaData.getImportedKeys()` for each table in the schema and runs `ALTER TABLE ... DROP CONSTRAINT` for every incoming foreign key.
- With the constraints removed first, the subsequent `DROP TABLE` sequence succeeds regardless of order.
- Adds `cleanTablesWithForeignKeys` intergration test that creates `parent_table` and `child_table` linked by a foreign key, then verifies `flyway.clean()` removes both.

## Validation
Tested locally with Java 21:
```sh
sh ./mvnw -pl flyway-database-cubrid test
```
Result:
```
Tests run: 7, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```