### PR TITLE
Add Aurora DSQL community database support

### DIFF
--- a/flyway-database-dsql/README.md
+++ b/flyway-database-dsql/README.md
@@ -1,0 +1,180 @@
+# flyway-database-dsql
+
+Flyway community database support for [Amazon Aurora DSQL](https://docs.aws.amazon.com/aurora-dsql/).
+
+## DSQL-Specific Behavior
+
+This module adapts Flyway's PostgreSQL support for Aurora DSQL's distributed architecture:
+
+- **One DDL per transaction**: DSQL accepts a single DDL statement per transaction, with DML in its
+  own. Flyway commits a migration file as one transaction, so keep one DDL statement per file (see
+  [One DDL statement per migration](#one-ddl-statement-per-migration))
+- **IAM authentication**: role-based access via IAM replaces PostgreSQL's `SET ROLE`
+- **Optimistic concurrency**: DSQL uses OCC instead of advisory locks, and surfaces conflicts
+  (`OC000` / `OC001` / `40001`) at commit time. The module can retry the migration transaction on a
+  conflict — off by default, opt in via [Configuration](#configuration). Run migrations from a single instance
+- **Async indexes**: use `CREATE INDEX ASYNC` in migrations, with an optional wait for the build
+  (see [Asynchronous indexes](#asynchronous-indexes))
+
+## Requirements
+
+- The [Aurora DSQL JDBC connector](https://github.com/awslabs/aurora-dsql-connectors/tree/main/java/jdbc)
+  on the runtime classpath for `jdbc:aws-dsql:postgresql://` URLs. It is not bundled by this module, so you supply
+  it yourself. A plain `jdbc:postgresql://` DSQL endpoint uses the PostgreSQL driver instead and does
+  not need the connector, but you must then generate the IAM token yourself and pass it as the
+  password.
+- AWS credentials on the default provider chain
+- IAM permission `dsql:DbConnectAdmin` on the cluster
+
+## Quick Start
+
+### 1. Configure Flyway
+
+```properties
+# flyway.conf
+flyway.url=jdbc:aws-dsql:postgresql://<CLUSTER_ID>.dsql.<REGION>.on.aws:5432/postgres
+flyway.user=admin
+flyway.driver=software.amazon.dsql.jdbc.DSQLConnector
+```
+
+Both `jdbc:aws-dsql:postgresql://` and `jdbc:postgresql://<host>.dsql.<region>.on.aws` URLs are
+recognized. The connector generates the IAM token from the credential chain and parses the region
+from the host; no password is supplied.
+
+### 2. Run Migrations
+
+```bash
+flyway migrate
+```
+
+## Programmatic Usage
+
+```java
+Flyway flyway = Flyway.configure()
+    .dataSource(
+        "jdbc:aws-dsql:postgresql://<CLUSTER_ID>.dsql.<REGION>.on.aws:5432/postgres",
+        "admin",
+        null)  // Password is null - IAM auth is automatic
+    .baselineOnMigrate(true)
+    .locations("classpath:db/migration")
+    .load();
+
+flyway.migrate();
+```
+
+## Writing DSQL-Compatible Migrations
+
+### Index Creation
+
+Use `CREATE INDEX ASYNC` for all indexes:
+
+```sql
+CREATE INDEX ASYNC idx_users_email ON users(email);
+```
+
+DSQL has no synchronous index creation — see [Asynchronous indexes](#asynchronous-indexes).
+
+### One DDL statement per migration
+
+DSQL accepts a single DDL statement per transaction, with DML in its own. Flyway commits a whole
+migration file as one transaction, so give each file one DDL statement:
+
+```sql
+-- V1__create_users.sql
+CREATE TABLE users (id INT PRIMARY KEY, email VARCHAR(255));
+```
+
+To hold several statements in one file, switch off the wrapping transaction for it with a script
+configuration file alongside the migration:
+
+```properties
+# V2__seed_users.sql.conf
+executeInTransaction=false
+```
+
+Each statement then commits on its own. Note that OCC retry does not apply to a migration running
+outside a transaction.
+
+### Transaction Limits
+
+Be aware of these per-transaction limits when writing migrations:
+
+- Maximum 3,000 rows
+- Maximum 10 MiB data size
+- Maximum 5 minutes duration
+
+## Configuration
+
+Parameters live under the `flyway.dsql.` namespace, set through any Flyway surface (config file,
+CLI flag, environment variable, or the Java API). OCC retry is off by default; the example
+below opts in with 3 retries, a reasonable starting point. In `flyway.conf` / `flyway.toml`:
+
+```
+flyway.dsql.occMaxRetries=3
+flyway.dsql.occMaxRetryDelaySeconds=5
+flyway.dsql.awaitAsyncIndexes=false
+```
+
+| Parameter | Default | Description |
+|---|---|---|
+| `occMaxRetries` | `0` | Max retries of a migration transaction that fails with an OCC conflict. `0` disables retries; set a positive value to enable. |
+| `occMaxRetryDelaySeconds` | `5` | Upper bound on the exponential backoff between OCC retries. |
+| `awaitAsyncIndexes` | `false` | When `true`, wait for `CREATE INDEX ASYNC` builds before the migration returns. |
+
+Equivalent environment variables: `FLYWAY_DSQL_OCC_MAX_RETRIES`,
+`FLYWAY_DSQL_OCC_MAX_RETRY_DELAY_SECONDS`, `FLYWAY_DSQL_AWAIT_ASYNC_INDEXES`.
+
+## Asynchronous indexes
+
+`CREATE INDEX ASYNC` returns immediately with a runtime `job_id` and builds the index in the
+background, so a plain migration reports success while the index is still building.
+
+With `awaitAsyncIndexes=true`, a SQL migration running `CREATE INDEX ASYNC` captures that `job_id`
+and blocks (via `sys.wait_for_job`) until the build finishes; if it fails, the migration fails.
+
+- **Off by default** — fire-and-forget is faster for a pure performance index. Enable the wait when
+  a later migration needs the index built, or a failed build should fail the deploy. The wait runs
+  after the script finishes, so it gates a later migration, not an earlier statement in the same
+  file.
+- **SQL migrations only** — Java migrations can capture the `job_id` and call `sys.wait_for_job`
+  themselves.
+- **A failed build leaves an `INVALID` index** — neither DSQL nor the migration drops it (a timed-out
+  wait may front a build that still succeeds). Drop it before rerunning; `IF NOT EXISTS` can silently
+  accept the `INVALID` index.
+
+## Not Yet Supported
+
+- `flyway undo` (Flyway Teams feature) — untested with DSQL
+- `flyway baseline` — use `baselineOnMigrate=true` instead (see [Troubleshooting](#ddl-and-dml-are-not-supported-in-the-same-transaction))
+
+## Troubleshooting
+
+### "No database found to handle jdbc:aws-dsql:"
+
+Either the Aurora DSQL JDBC connector is not on the classpath (see [Requirements](#requirements)), or
+the URL omits the `postgresql://` segment. The connector accepts only
+`jdbc:aws-dsql:postgresql://<host>/<database>`.
+
+### "ddl and dml are not supported in the same transaction"
+
+Flyway commits a migration file as one transaction, and DSQL runs one DDL statement per transaction
+with DML in its own. This error therefore comes either from a migration file that mixes DDL and DML
+(see [One DDL statement per migration](#one-ddl-statement-per-migration)), or from the standalone
+`flyway baseline` command, whose create-table and marker insert share a transaction. For baseline,
+use `baselineOnMigrate` instead:
+
+```properties
+# flyway.conf
+flyway.baselineOnMigrate=true
+flyway.baselineVersion=1
+```
+
+### Token/Authentication Errors
+
+- Verify IAM permissions include `dsql:DbConnectAdmin`
+- Check AWS credentials resolve on the default provider chain
+- Ensure the region parsed from the endpoint is correct
+
+## License
+
+This project is licensed under the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0).

--- a/flyway-database-dsql/README.md
+++ b/flyway-database-dsql/README.md
@@ -1,0 +1,150 @@
+# flyway-database-dsql
+
+Flyway community database support for [Amazon Aurora DSQL](https://docs.aws.amazon.com/aurora-dsql/).
+
+## DSQL-Specific Behavior
+
+This module adapts Flyway's PostgreSQL support for Aurora DSQL's distributed architecture:
+
+- **One DDL per transaction**: each schema change runs in its own transaction automatically
+- **IAM authentication**: role-based access via IAM replaces PostgreSQL's `SET ROLE`
+- **Optimistic concurrency**: DSQL uses OCC instead of advisory locks, and surfaces conflicts
+  (`OC000` / `OC001` / `40001`) at commit time. The module can retry the migration transaction on a
+  conflict — off by default, opt in via [Configuration](#configuration). Run migrations from a single instance
+- **Async indexes**: use `CREATE INDEX ASYNC` in migrations, with an optional wait for the build
+  (see [Asynchronous indexes](#asynchronous-indexes))
+
+## Requirements
+
+- The [Aurora DSQL JDBC connector](https://github.com/awslabs/aurora-dsql-connectors/tree/main/java/jdbc)
+  on the runtime classpath. It is required to connect, but not bundled by this module, so you
+  supply it yourself.
+- AWS credentials on the default provider chain
+- IAM permission `dsql:DbConnectAdmin` on the cluster
+
+## Quick Start
+
+### 1. Configure Flyway
+
+```properties
+# flyway.conf
+flyway.url=jdbc:aws-dsql:postgresql://<CLUSTER_ID>.dsql.<REGION>.on.aws:5432/postgres
+flyway.user=admin
+flyway.driver=software.amazon.dsql.jdbc.DSQLConnector
+```
+
+Both `jdbc:aws-dsql:postgresql://` and `jdbc:postgresql://<host>.dsql.<region>.on.aws` URLs are
+recognized. The connector generates the IAM token from the credential chain and parses the region
+from the host; no password is supplied.
+
+### 2. Run Migrations
+
+```bash
+flyway migrate
+```
+
+## Programmatic Usage
+
+```java
+Flyway flyway = Flyway.configure()
+    .dataSource(
+        "jdbc:aws-dsql:postgresql://<CLUSTER_ID>.dsql.<REGION>.on.aws:5432/postgres",
+        "admin",
+        null)  // Password is null - IAM auth is automatic
+    .baselineOnMigrate(true)
+    .locations("classpath:db/migration")
+    .load();
+
+flyway.migrate();
+```
+
+## Writing DSQL-Compatible Migrations
+
+### Index Creation
+
+Use `CREATE INDEX ASYNC` for all indexes:
+
+```sql
+CREATE INDEX ASYNC idx_users_email ON users(email);
+```
+
+DSQL has no synchronous index creation — see [Asynchronous indexes](#asynchronous-indexes).
+
+### Transaction Limits
+
+Be aware of these per-transaction limits when writing migrations:
+
+- Maximum 3,000 rows
+- Maximum 10 MiB data size
+- Maximum 5 minutes duration
+
+## Configuration
+
+Parameters live under the `flyway.dsql.` namespace, set through any Flyway surface (config file,
+CLI flag, environment variable, or the Java API). OCC retry is off by default; the example
+below opts in with 3 retries, a reasonable starting point. In `flyway.conf` / `flyway.toml`:
+
+```
+flyway.dsql.occMaxRetries=3
+flyway.dsql.occMaxRetryDelaySeconds=5
+flyway.dsql.awaitAsyncIndexes=false
+```
+
+| Parameter | Default | Description |
+|---|---|---|
+| `occMaxRetries` | `0` | Max retries of a migration transaction that fails with an OCC conflict. `0` disables retries; set a positive value to enable. |
+| `occMaxRetryDelaySeconds` | `5` | Upper bound on the exponential backoff between OCC retries. |
+| `awaitAsyncIndexes` | `false` | When `true`, wait for `CREATE INDEX ASYNC` builds before the migration returns. |
+
+Equivalent environment variables: `FLYWAY_DSQL_OCC_MAX_RETRIES`,
+`FLYWAY_DSQL_OCC_MAX_RETRY_DELAY_SECONDS`, `FLYWAY_DSQL_AWAIT_ASYNC_INDEXES`.
+
+## Asynchronous indexes
+
+`CREATE INDEX ASYNC` returns immediately with a runtime `job_id` and builds the index in the
+background, so a plain migration reports success while the index is still building.
+
+With `awaitAsyncIndexes=true`, a SQL migration running `CREATE INDEX ASYNC` captures that `job_id`
+and blocks (via `sys.wait_for_job`) until the build finishes; if it fails, the migration fails.
+
+- **Off by default** — fire-and-forget is faster for a pure performance index. Enable the wait when
+  a later migration needs the index built, or a failed build should fail the deploy. The wait runs
+  after the script finishes, so it gates a later migration, not an earlier statement in the same
+  file.
+- **SQL migrations only** — Java migrations can capture the `job_id` and call `sys.wait_for_job`
+  themselves.
+- **A failed build leaves an `INVALID` index** — neither DSQL nor the migration drops it (a timed-out
+  wait may front a build that still succeeds). Drop it before rerunning; `IF NOT EXISTS` can silently
+  accept the `INVALID` index.
+
+## Not Yet Supported
+
+- `flyway undo` (Flyway Teams feature) — untested with DSQL
+- `flyway baseline` — use `baselineOnMigrate=true` instead (see [Troubleshooting](#ddl-and-dml-are-not-supported-in-the-same-transaction))
+
+## Troubleshooting
+
+### "No database found to handle jdbc:aws-dsql:"
+
+The Aurora DSQL JDBC connector is not on the classpath (see [Requirements](#requirements)).
+
+### "ddl and dml are not supported in the same transaction"
+
+This occurs with the standalone `flyway baseline` command — DSQL does not allow DDL and DML in the
+same transaction. Use `baselineOnMigrate` instead:
+
+```properties
+# flyway.conf
+flyway.baselineOnMigrate=true
+flyway.baselineVersion=1
+```
+
+### Token/Authentication Errors
+
+- Verify IAM permissions include `dsql:DbConnectAdmin`
+- Check AWS credentials resolve on the default provider chain
+- Ensure the region parsed from the endpoint is correct
+
+## License
+
+This project is licensed under the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0).

--- a/flyway-database-dsql/pom.xml
+++ b/flyway-database-dsql/pom.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.flywaydb</groupId>
+        <artifactId>flyway-community-db-support</artifactId>
+        <version>10.25.16</version>
+    </parent>
+
+    <artifactId>flyway-database-dsql</artifactId>
+    <name>${project.artifactId}</name>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>5.11.0</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>flyway-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>flyway-database-postgresql</artifactId>
+            <version>${version.flyway}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.flywaydb</groupId>
+                    <artifactId>flyway-core</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.26.3</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- Aurora DSQL JDBC connector: provides the jdbc:aws-dsql:postgresql:// driver for the env-gated live
+             integration test. Test-scoped because nothing in main references it - users supply the
+             driver at runtime, and keeping it off the main classpath means the module cannot regress
+             into requiring it on the jdbc:postgresql:// endpoint form, where it is not the driver. -->
+        <dependency>
+            <groupId>software.amazon.dsql</groupId>
+            <artifactId>aurora-dsql-jdbc-connector</artifactId>
+            <version>1.5.0</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+        <plugins>
+            <plugin>
+                <artifactId>maven-resources-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.3.1</version>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/flyway-database-dsql/pom.xml
+++ b/flyway-database-dsql/pom.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.flywaydb</groupId>
+        <artifactId>flyway-community-db-support</artifactId>
+        <version>10.25.16</version>
+    </parent>
+
+    <artifactId>flyway-database-dsql</artifactId>
+    <name>${project.artifactId}</name>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>5.11.0</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>flyway-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>flyway-database-postgresql</artifactId>
+            <version>${version.flyway}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.flywaydb</groupId>
+                    <artifactId>flyway-core</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.26.3</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- Aurora DSQL JDBC connector: source of the OCC contract reused by the retry decorator
+             (OCCRetry.isOCCError, OCCRetryConfig). Optional so it is not bundled and users supply
+             the driver at runtime, matching how sibling modules scope their JDBC drivers. Also
+             provides the jdbc:aws-dsql: driver for the env-gated live integration test. -->
+        <dependency>
+            <groupId>software.amazon.dsql</groupId>
+            <artifactId>aurora-dsql-jdbc-connector</artifactId>
+            <version>1.5.0</version>
+            <optional>true</optional>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+        <plugins>
+            <plugin>
+                <artifactId>maven-resources-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.3.1</version>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/flyway-database-dsql/src/main/java/org/flywaydb/community/database/DSQLDatabaseExtension.java
+++ b/flyway-database-dsql/src/main/java/org/flywaydb/community/database/DSQLDatabaseExtension.java
@@ -1,0 +1,43 @@
+/*-
+ * ========================LICENSE_START=================================
+ * flyway-database-dsql
+ * ========================================================================
+ * Copyright (C) 2010 - 2026 Red Gate Software Ltd
+ * ========================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+package org.flywaydb.community.database;
+
+import org.flywaydb.core.api.FlywayException;
+import org.flywaydb.core.extensibility.PluginMetadata;
+import org.flywaydb.core.internal.util.FileUtils;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+public class DSQLDatabaseExtension implements PluginMetadata {
+    public String getDescription() {
+        return "Community-contributed Amazon Aurora DSQL database support extension " + readVersion() + " by Redgate";
+    }
+
+    public static String readVersion() {
+        try {
+            return FileUtils.copyToString(
+                    DSQLDatabaseExtension.class.getClassLoader().getResourceAsStream("org/flywaydb/community/database/dsql/version.txt"),
+                    StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new FlywayException("Unable to read extension version: " + e.getMessage(), e);
+        }
+    }
+}

--- a/flyway-database-dsql/src/main/java/org/flywaydb/community/database/dsql/DSQLConfigurationExtension.java
+++ b/flyway-database-dsql/src/main/java/org/flywaydb/community/database/dsql/DSQLConfigurationExtension.java
@@ -1,0 +1,91 @@
+/*-
+ * ========================LICENSE_START=================================
+ * flyway-database-dsql
+ * ========================================================================
+ * Copyright (C) 2010 - 2026 Red Gate Software Ltd
+ * ========================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+package org.flywaydb.community.database.dsql;
+
+import org.flywaydb.core.extensibility.ConfigurationExtension;
+
+/**
+ * Configuration for Aurora DSQL behavior, under the {@code dsql} namespace.
+ *
+ * <p>OCC retry is off by default ({@code occMaxRetries=0}). Enable it via
+ * {@code flyway.dsql.occMaxRetries} (a positive value) and tune the backoff cap with
+ * {@code flyway.dsql.occMaxRetryDelaySeconds} (or the matching {@code FLYWAY_DSQL_*}
+ * environment variables); 3 retries with a 5s cap is a reasonable starting point.
+ *
+ * <p>Async index waiting is opt-in, off by default. Set
+ * {@code flyway.dsql.awaitAsyncIndexes=true} (or {@code FLYWAY_DSQL_AWAIT_ASYNC_INDEXES}) to
+ * block on {@code CREATE INDEX ASYNC} builds until they complete.
+ *
+ * <p>Must remain a pure JavaBean: Flyway deep-copies it via {@link #copy()} using Jackson.
+ * Do not store computed / non-bean state here.
+ */
+public class DSQLConfigurationExtension implements ConfigurationExtension {
+
+    private static final String ENV_MAX_RETRIES = "FLYWAY_DSQL_OCC_MAX_RETRIES";
+    private static final String ENV_MAX_RETRY_DELAY_SECONDS = "FLYWAY_DSQL_OCC_MAX_RETRY_DELAY_SECONDS";
+    private static final String ENV_AWAIT_ASYNC_INDEXES = "FLYWAY_DSQL_AWAIT_ASYNC_INDEXES";
+
+    private int occMaxRetries = 0;
+    private int occMaxRetryDelaySeconds = 5;
+    private boolean awaitAsyncIndexes = false;
+
+    public int getOccMaxRetries() {
+        return occMaxRetries;
+    }
+
+    public void setOccMaxRetries(int occMaxRetries) {
+        this.occMaxRetries = occMaxRetries;
+    }
+
+    public int getOccMaxRetryDelaySeconds() {
+        return occMaxRetryDelaySeconds;
+    }
+
+    public void setOccMaxRetryDelaySeconds(int occMaxRetryDelaySeconds) {
+        this.occMaxRetryDelaySeconds = occMaxRetryDelaySeconds;
+    }
+
+    public boolean isAwaitAsyncIndexes() {
+        return awaitAsyncIndexes;
+    }
+
+    public void setAwaitAsyncIndexes(boolean awaitAsyncIndexes) {
+        this.awaitAsyncIndexes = awaitAsyncIndexes;
+    }
+
+    @Override
+    public String getNamespace() {
+        return "dsql";
+    }
+
+    @Override
+    public String getConfigurationParameterFromEnvironmentVariable(String environmentVariable) {
+        switch (environmentVariable) {
+            case ENV_MAX_RETRIES:
+                return "flyway.dsql.occMaxRetries";
+            case ENV_MAX_RETRY_DELAY_SECONDS:
+                return "flyway.dsql.occMaxRetryDelaySeconds";
+            case ENV_AWAIT_ASYNC_INDEXES:
+                return "flyway.dsql.awaitAsyncIndexes";
+            default:
+                return null;
+        }
+    }
+}

--- a/flyway-database-dsql/src/main/java/org/flywaydb/community/database/dsql/DSQLConnection.java
+++ b/flyway-database-dsql/src/main/java/org/flywaydb/community/database/dsql/DSQLConnection.java
@@ -1,0 +1,123 @@
+/*-
+ * ========================LICENSE_START=================================
+ * flyway-database-dsql
+ * ========================================================================
+ * Copyright (C) 2010 - 2026 Red Gate Software Ltd
+ * ========================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+package org.flywaydb.community.database.dsql;
+
+import lombok.CustomLog;
+import org.flywaydb.core.internal.database.base.Schema;
+import org.flywaydb.core.internal.database.base.Table;
+import org.flywaydb.core.internal.exception.FlywaySqlException;
+import org.flywaydb.database.postgresql.PostgreSQLConnection;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.concurrent.Callable;
+
+/**
+ * Aurora DSQL connection implementation for Flyway.
+ *
+ * <p>Skips {@code SET ROLE} restoration (DSQL uses IAM authentication) and bypasses
+ * advisory locks (DSQL uses optimistic concurrency control).
+ */
+@CustomLog
+public class DSQLConnection extends PostgreSQLConnection {
+
+    public DSQLConnection(DSQLDatabase database, Connection connection) {
+        super(database, connection);
+    }
+
+    @Override
+    protected void doRestoreOriginalState() throws SQLException {
+        LOG.debug("Skipping SET ROLE restoration (not supported by Aurora DSQL)");
+    }
+
+    @Override
+    public Schema getSchema(String name) {
+        return new DSQLSchema(jdbcTemplate, (DSQLDatabase) database, name);
+    }
+
+    @Override
+    public <T> T lock(Table table, Callable<T> callable) {
+        LOG.debug("Executing without advisory lock (not supported by Aurora DSQL)");
+        try {
+            T result = callable.call();
+            reconcileDuplicateHistoryRows(table);
+            return result;
+        } catch (SQLException e) {
+            throw new FlywaySqlException("Unable to execute migration", e);
+        } catch (RuntimeException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new RuntimeException("Unable to execute migration", e);
+        }
+    }
+
+    /**
+     * Removes duplicate schema-history rows left by an OCC retry.
+     *
+     * <p>DSQL keeps the migration's schema-history insert on the auto-commit main connection, so it
+     * commits before the migration transaction's own commit. When that commit loses the OCC race and
+     * {@link DSQLExecutionTemplate} replays the migration, a second history row is written for the
+     * same version — leaving the earlier attempt's row orphaned (a lower {@code installed_rank}).
+     * See {@link #reconcileStatement(String)} for what is deleted.
+     *
+     * <p>Best-effort and idempotent: a no-op when there are no duplicates, and never fails the
+     * migration if cleanup itself errors. The schema-creation marker, which carries no version, is
+     * left untouched.
+     */
+    private void reconcileDuplicateHistoryRows(Table table) {
+        try {
+            // lock() also wraps the history-table create/drop; skip those (e.g. after clean drops
+            // the table) so the DELETE does not run against a missing table. The main connection is
+            // already auto-commit, so the DELETE commits on its own.
+            if (!table.exists()) {
+                return;
+            }
+            jdbcTemplate.execute(reconcileStatement(table.toString()));
+        } catch (Exception e) {
+            // Best-effort: never fail an already-succeeded migration. Broad catch because
+            // table.exists() rethrows its SQLException unchecked.
+            LOG.warn("Could not reconcile duplicate Aurora DSQL schema-history rows: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Deletes lower-ranked successful rows duplicating a higher-ranked successful row of the same
+     * version <em>and type</em> — the shape an OCC retry leaves.
+     *
+     * <p>Type is compared because Flyway encodes state as same-version rows that are not duplicates:
+     * {@code repair} appends a {@code DELETE} marker and {@code undo} its own entry <em>above</em> the
+     * row they refer to, so matching on version alone would delete that row.
+     *
+     * <p>Success is compared on both sides because a migration that exhausts its retries records a
+     * failed row above the successful ones (DSQL records failures, having no DDL transactions).
+     * Taking {@code MAX} over successful rows only keeps that failed row from making every
+     * successful row below it look superseded.
+     */
+    static String reconcileStatement(String table) {
+        return "DELETE FROM " + table + " h"
+                + " WHERE h.\"version\" IS NOT NULL"
+                + " AND h.\"success\" = TRUE"
+                + " AND h.\"installed_rank\" < ("
+                + "SELECT MAX(h2.\"installed_rank\") FROM " + table + " h2"
+                + " WHERE h2.\"version\" = h.\"version\""
+                + " AND h2.\"type\" = h.\"type\""
+                + " AND h2.\"success\" = TRUE)";
+    }
+}

--- a/flyway-database-dsql/src/main/java/org/flywaydb/community/database/dsql/DSQLConnection.java
+++ b/flyway-database-dsql/src/main/java/org/flywaydb/community/database/dsql/DSQLConnection.java
@@ -1,0 +1,106 @@
+/*-
+ * ========================LICENSE_START=================================
+ * flyway-database-dsql
+ * ========================================================================
+ * Copyright (C) 2010 - 2026 Red Gate Software Ltd
+ * ========================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+package org.flywaydb.community.database.dsql;
+
+import org.flywaydb.core.internal.database.base.Schema;
+import org.flywaydb.core.internal.database.base.Table;
+import org.flywaydb.core.internal.exception.FlywaySqlException;
+import org.flywaydb.database.postgresql.PostgreSQLConnection;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.concurrent.Callable;
+import java.util.logging.Logger;
+
+/**
+ * Aurora DSQL connection implementation for Flyway.
+ *
+ * <p>Skips {@code SET ROLE} restoration (DSQL uses IAM authentication) and bypasses
+ * advisory locks (DSQL uses optimistic concurrency control).
+ */
+public class DSQLConnection extends PostgreSQLConnection {
+
+    private static final Logger LOG = Logger.getLogger(DSQLConnection.class.getName());
+
+    public DSQLConnection(DSQLDatabase database, Connection connection) {
+        super(database, connection);
+    }
+
+    @Override
+    protected void doRestoreOriginalState() throws SQLException {
+        LOG.fine("Skipping SET ROLE restoration (not supported by Aurora DSQL)");
+    }
+
+    @Override
+    public Schema getSchema(String name) {
+        return new DSQLSchema(jdbcTemplate, (DSQLDatabase) database, name);
+    }
+
+    @Override
+    public <T> T lock(Table table, Callable<T> callable) {
+        LOG.fine("Executing without advisory lock (not supported by Aurora DSQL)");
+        try {
+            T result = callable.call();
+            reconcileDuplicateHistoryRows(table);
+            return result;
+        } catch (SQLException e) {
+            throw new FlywaySqlException("Unable to execute migration", e);
+        } catch (RuntimeException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new RuntimeException("Unable to execute migration", e);
+        }
+    }
+
+    /**
+     * Removes duplicate schema-history rows left by an OCC retry.
+     *
+     * <p>DSQL keeps the migration's schema-history insert on the auto-commit main connection, so it
+     * commits before the migration transaction's own commit. When that commit loses the OCC race and
+     * {@link DSQLExecutionTemplate} replays the migration, a second history row is written for the
+     * same version — leaving the earlier attempt's row orphaned (a lower {@code installed_rank}).
+     * This keeps the highest {@code installed_rank} per version and deletes the lower duplicates.
+     *
+     * <p>Best-effort and idempotent: a no-op when there are no duplicates, and never fails the
+     * migration if cleanup itself errors. Rows with no version (baseline / schema markers) are left
+     * untouched.
+     */
+    private void reconcileDuplicateHistoryRows(Table table) {
+        String deleteDuplicates =
+                "DELETE FROM " + table + " h"
+                        + " WHERE h.\"version\" IS NOT NULL"
+                        + " AND h.\"installed_rank\" < ("
+                        + "SELECT MAX(h2.\"installed_rank\") FROM " + table + " h2"
+                        + " WHERE h2.\"version\" = h.\"version\")";
+        try {
+            // lock() also wraps the history-table create/drop; skip those (e.g. after clean drops
+            // the table) so the DELETE does not run against a missing table. The main connection is
+            // already auto-commit, so the DELETE commits on its own.
+            if (!table.exists()) {
+                return;
+            }
+            jdbcTemplate.execute(deleteDuplicates);
+        } catch (Exception e) {
+            // Best-effort: never fail an already-succeeded migration. Broad catch because
+            // table.exists() rethrows its SQLException unchecked.
+            LOG.warning("Could not reconcile duplicate Aurora DSQL schema-history rows: " + e.getMessage());
+        }
+    }
+}

--- a/flyway-database-dsql/src/main/java/org/flywaydb/community/database/dsql/DSQLDatabase.java
+++ b/flyway-database-dsql/src/main/java/org/flywaydb/community/database/dsql/DSQLDatabase.java
@@ -1,0 +1,89 @@
+/*-
+ * ========================LICENSE_START=================================
+ * flyway-database-dsql
+ * ========================================================================
+ * Copyright (C) 2010 - 2026 Red Gate Software Ltd
+ * ========================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+package org.flywaydb.community.database.dsql;
+
+import org.flywaydb.core.api.configuration.Configuration;
+import org.flywaydb.core.internal.database.base.Table;
+import org.flywaydb.core.internal.jdbc.JdbcConnectionFactory;
+import org.flywaydb.core.internal.jdbc.StatementInterceptor;
+import org.flywaydb.database.postgresql.PostgreSQLDatabase;
+
+import java.sql.Connection;
+
+/**
+ * Aurora DSQL database implementation for Flyway.
+ *
+ * <p>Extends PostgreSQL with DSQL-specific behavior: disables DDL transactions, uses an
+ * inline primary key in the schema-history create script, and keeps DDL and DML in
+ * separate transactions.
+ *
+ * <p>Baseline: use {@code baselineOnMigrate} rather than the standalone {@code baseline}
+ * command. DSQL forbids DDL and DML in one transaction, so the create-table and the baseline
+ * marker insert must run in separate transactions. {@code baselineOnMigrate} does this (the
+ * marker is inserted after the table is created), whereas the {@code baseline} command relies
+ * on a single-transaction create script carrying the marker insert, which DSQL rejects.
+ */
+public class DSQLDatabase extends PostgreSQLDatabase {
+
+    public DSQLDatabase(Configuration configuration,
+                        JdbcConnectionFactory jdbcConnectionFactory,
+                        StatementInterceptor statementInterceptor) {
+        super(configuration, jdbcConnectionFactory, statementInterceptor);
+    }
+
+    @Override
+    protected DSQLConnection doGetConnection(Connection connection) {
+        return new DSQLConnection(this, connection);
+    }
+
+    @Override
+    public boolean supportsDdlTransactions() {
+        // DSQL allows only one DDL statement per transaction and cannot mix DDL and DML.
+        return false;
+    }
+
+    @Override
+    public String getRawCreateScript(Table table, boolean baseline) {
+        // DSQL does not support ALTER TABLE ADD CONSTRAINT, so the primary key is defined
+        // inline. Only one DDL statement is allowed per transaction, so no CREATE INDEX is
+        // bundled here. The baseline marker is intentionally never appended (the baseline flag
+        // is ignored): DSQL forbids DDL and DML in one transaction, so a create script carrying
+        // the marker insert would be rejected. baselineOnMigrate inserts the marker in a separate
+        // transaction instead; the standalone baseline command is unsupported on DSQL.
+        return "CREATE TABLE " + table + " (\n" +
+               "    \"installed_rank\" INT NOT NULL PRIMARY KEY,\n" +
+               "    \"version\" VARCHAR(50),\n" +
+               "    \"description\" VARCHAR(200) NOT NULL,\n" +
+               "    \"type\" VARCHAR(20) NOT NULL,\n" +
+               "    \"script\" VARCHAR(1000) NOT NULL,\n" +
+               "    \"checksum\" INT,\n" +
+               "    \"installed_by\" VARCHAR(100) NOT NULL,\n" +
+               "    \"installed_on\" TIMESTAMP NOT NULL DEFAULT now(),\n" +
+               "    \"execution_time\" INT NOT NULL,\n" +
+               "    \"success\" BOOLEAN NOT NULL\n" +
+               ")";
+    }
+
+    @Override
+    public boolean useSingleConnection() {
+        // DSQL needs DDL and DML in separate transactions.
+        return false;
+    }
+}

--- a/flyway-database-dsql/src/main/java/org/flywaydb/community/database/dsql/DSQLDatabase.java
+++ b/flyway-database-dsql/src/main/java/org/flywaydb/community/database/dsql/DSQLDatabase.java
@@ -1,0 +1,105 @@
+/*-
+ * ========================LICENSE_START=================================
+ * flyway-database-dsql
+ * ========================================================================
+ * Copyright (C) 2010 - 2026 Red Gate Software Ltd
+ * ========================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+package org.flywaydb.community.database.dsql;
+
+import org.flywaydb.core.api.configuration.Configuration;
+import org.flywaydb.core.internal.database.base.Table;
+import org.flywaydb.core.internal.jdbc.JdbcConnectionFactory;
+import org.flywaydb.core.internal.jdbc.StatementInterceptor;
+import org.flywaydb.database.postgresql.PostgreSQLDatabase;
+
+import java.sql.Connection;
+
+/**
+ * Aurora DSQL database implementation for Flyway.
+ *
+ * <p>Extends PostgreSQL with DSQL-specific behavior: disables DDL transactions, uses an
+ * inline primary key in the schema-history create script, and keeps DDL and DML in
+ * separate transactions.
+ *
+ * <p>Baseline: use {@code baselineOnMigrate} rather than the standalone {@code baseline}
+ * command. DSQL forbids DDL and DML in one transaction, so the create-table and the baseline
+ * marker insert must run in separate transactions. {@code baselineOnMigrate} does this (the
+ * marker is inserted after the table is created), whereas the {@code baseline} command relies
+ * on a single-transaction create script carrying the marker insert, which DSQL rejects.
+ */
+public class DSQLDatabase extends PostgreSQLDatabase {
+
+    public DSQLDatabase(Configuration configuration,
+                        JdbcConnectionFactory jdbcConnectionFactory,
+                        StatementInterceptor statementInterceptor) {
+        super(configuration, jdbcConnectionFactory, statementInterceptor);
+    }
+
+    @Override
+    protected DSQLConnection doGetConnection(Connection connection) {
+        return new DSQLConnection(this, connection);
+    }
+
+    @Override
+    public boolean supportsDdlTransactions() {
+        // DSQL allows only one DDL statement per transaction and cannot mix DDL and DML.
+        return false;
+    }
+
+    @Override
+    public String getRawCreateScript(Table table, boolean baseline) {
+        // DSQL does not support ALTER TABLE ADD CONSTRAINT, so the primary key is defined
+        // inline. Only one DDL statement is allowed per transaction, so no CREATE INDEX is
+        // bundled here. The baseline marker is intentionally never appended (the baseline flag
+        // is ignored): DSQL forbids DDL and DML in one transaction, so a create script carrying
+        // the marker insert would be rejected. baselineOnMigrate inserts the marker in a separate
+        // transaction instead; the standalone baseline command is unsupported on DSQL.
+        return "CREATE TABLE " + table + " (\n" +
+               "    \"installed_rank\" INT NOT NULL PRIMARY KEY,\n" +
+               "    \"version\" VARCHAR(50),\n" +
+               "    \"description\" VARCHAR(200) NOT NULL,\n" +
+               "    \"type\" VARCHAR(20) NOT NULL,\n" +
+               "    \"script\" VARCHAR(1000) NOT NULL,\n" +
+               "    \"checksum\" INT,\n" +
+               "    \"installed_by\" VARCHAR(100) NOT NULL,\n" +
+               "    \"installed_on\" TIMESTAMP NOT NULL DEFAULT now(),\n" +
+               "    \"execution_time\" INT NOT NULL,\n" +
+               "    \"success\" BOOLEAN NOT NULL\n" +
+               ")";
+    }
+
+    @Override
+    public String getInsertStatement(Table table) {
+        return "INSERT INTO " + table
+                + " (" + quote("installed_rank")
+                + ", " + quote("version")
+                + ", " + quote("description")
+                + ", " + quote("type")
+                + ", " + quote("script")
+                + ", " + quote("checksum")
+                + ", " + quote("installed_by")
+                + ", " + quote("execution_time")
+                + ", " + quote("success")
+                + ")"
+                + " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)";
+    }
+
+    @Override
+    public boolean useSingleConnection() {
+        // DSQL needs DDL and DML in separate transactions.
+        return false;
+    }
+}

--- a/flyway-database-dsql/src/main/java/org/flywaydb/community/database/dsql/DSQLDatabaseType.java
+++ b/flyway-database-dsql/src/main/java/org/flywaydb/community/database/dsql/DSQLDatabaseType.java
@@ -1,0 +1,217 @@
+/*-
+ * ========================LICENSE_START=================================
+ * flyway-database-dsql
+ * ========================================================================
+ * Copyright (C) 2010 - 2026 Red Gate Software Ltd
+ * ========================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+package org.flywaydb.community.database.dsql;
+
+import org.flywaydb.community.database.DSQLDatabaseExtension;
+import org.flywaydb.core.api.ResourceProvider;
+import org.flywaydb.core.api.configuration.Configuration;
+import org.flywaydb.core.internal.callback.CallbackExecutor;
+import org.flywaydb.core.internal.database.base.CommunityDatabaseType;
+import org.flywaydb.core.internal.database.base.Database;
+import org.flywaydb.core.internal.jdbc.ExecutionTemplate;
+import org.flywaydb.core.internal.jdbc.JdbcConnectionFactory;
+import org.flywaydb.core.internal.jdbc.StatementInterceptor;
+import org.flywaydb.core.internal.parser.Parser;
+import org.flywaydb.core.internal.parser.ParsingContext;
+import org.flywaydb.core.internal.sqlscript.SqlScriptExecutorFactory;
+import org.flywaydb.database.postgresql.PostgreSQLDatabaseType;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Collections;
+import java.util.Map;
+import java.util.WeakHashMap;
+
+/**
+ * Flyway database type for Amazon Aurora DSQL.
+ *
+ * <p>Extends PostgreSQL support to handle {@code jdbc:aws-dsql:postgresql://} URLs and DSQL endpoints.
+ * The Aurora DSQL JDBC connector transforms {@code jdbc:aws-dsql:postgresql://} URLs to
+ * {@code jdbc:postgresql://} internally, so DSQL is detected by both the URL prefix and the
+ * endpoint host pattern ({@code .dsql.} for public endpoints, {@code .dsql-} for PrivateLink).
+ */
+public class DSQLDatabaseType extends PostgreSQLDatabaseType implements CommunityDatabaseType {
+
+    // The only prefix the Aurora DSQL JDBC connector accepts (ConnUrlParser.isDsqlUrl); matching a
+    // broader jdbc:aws-dsql: prefix would claim URLs the connector then refuses to open.
+    private static final String DSQL_CONNECTOR_URL_PREFIX = "jdbc:aws-dsql:postgresql://";
+    private static final String DSQL_PUBLIC_PATTERN = ".dsql.";
+    private static final String DSQL_PRIVATELINK_PATTERN = ".dsql-";
+    private static final int DEFAULT_MAX_RETRIES = 0;
+    private static final int DEFAULT_MAX_RETRY_DELAY_SECONDS = 5;
+    private static final long MIN_RETRY_DELAY_MS = 100L;
+
+    private static final int[] DEFAULT_OCC_RETRY_KNOBS =
+            {DEFAULT_MAX_RETRIES, DEFAULT_MAX_RETRY_DELAY_SECONDS};
+
+    // DatabaseType is a JVM-global singleton resolved from a static registry, and the commit-wrapping
+    // seam (createTransactionalExecutionTemplate) receives only a Connection, no Configuration. The
+    // OCC retry knobs are therefore resolved in alterConnectionAsNeeded, which receives both, and
+    // keyed on that Connection. Weak keys so entries go when Flyway closes the connection.
+    // JdbcConnectionFactory skips alterConnectionAsNeeded for intercepted connections, which
+    // therefore fall back to the defaults (retry off). That path captures SQL rather than committing
+    // it, so there is no commit to lose an OCC race.
+    private static final Map<Connection, int[]> OCC_RETRY_KNOBS =
+            Collections.synchronizedMap(new WeakHashMap<>());
+
+    @Override
+    public String getName() {
+        return "Aurora DSQL";
+    }
+
+    @Override
+    public boolean handlesJDBCUrl(String url) {
+        if (url.startsWith(DSQL_CONNECTOR_URL_PREFIX)) {
+            return true;
+        }
+        return url.startsWith("jdbc:postgresql://") && isDsqlHost(url);
+    }
+
+    /**
+     * Matches the DSQL endpoint pattern against the URL's host only, so a {@code .dsql.} appearing
+     * elsewhere (database name, query parameter) cannot misclassify a plain PostgreSQL URL as DSQL.
+     */
+    private static boolean isDsqlHost(String jdbcUrl) {
+        String host = extractHost(jdbcUrl);
+        return host != null
+                && (host.contains(DSQL_PUBLIC_PATTERN) || host.contains(DSQL_PRIVATELINK_PATTERN));
+    }
+
+    /** Extracts the host from a {@code jdbc:...} URL, or null if it cannot be parsed. */
+    private static String extractHost(String jdbcUrl) {
+        int scheme = jdbcUrl.indexOf("://");
+        if (scheme < 0) {
+            return null;
+        }
+        try {
+            // Strip the "jdbc:" prefix so java.net.URI sees a single, parseable scheme.
+            URI uri = new URI(jdbcUrl.substring(jdbcUrl.indexOf(':') + 1));
+            return uri.getHost();
+        } catch (URISyntaxException e) {
+            return null;
+        }
+    }
+
+    @Override
+    public int getPriority() {
+        // Higher than PostgreSQL (0) so DSQL URLs are matched first.
+        return 1;
+    }
+
+    @Override
+    public boolean handlesDatabaseProductNameAndVersion(String databaseProductName,
+                                                        String databaseProductVersion,
+                                                        Connection connection) {
+        try {
+            String url = connection.getMetaData().getURL();
+            return url != null && isDsqlHost(url);
+        } catch (SQLException e) {
+            return false;
+        }
+    }
+
+    @Override
+    public String getDriverClass(String url, ClassLoader classLoader) {
+        if (url.startsWith(DSQL_CONNECTOR_URL_PREFIX)) {
+            return "software.amazon.dsql.jdbc.DSQLConnector";
+        }
+        return "org.postgresql.Driver";
+    }
+
+    /**
+     * Resolves the OCC retry knobs for this connection. Called for each connection Flyway opens
+     * directly, and receives the {@link Configuration} that {@link #createTransactionalExecutionTemplate}
+     * does not, so it is where the configured values enter the retry decorator.
+     */
+    @Override
+    public Connection alterConnectionAsNeeded(Connection connection, Configuration configuration) {
+        OCC_RETRY_KNOBS.put(connection, resolveOccRetryKnobs(configuration));
+        return super.alterConnectionAsNeeded(connection, configuration);
+    }
+
+    @Override
+    public Database createDatabase(Configuration configuration,
+                                   JdbcConnectionFactory jdbcConnectionFactory,
+                                   StatementInterceptor statementInterceptor) {
+        return new DSQLDatabase(configuration, jdbcConnectionFactory, statementInterceptor);
+    }
+
+    /**
+     * Wraps the base transactional template so a commit-time OCC conflict retries the whole
+     * migration transaction. This is the only Flyway seam that spans {@code connection.commit()},
+     * where DSQL surfaces {@code OC000}/{@code OC001}/{@code 40001}.
+     */
+    @Override
+    public ExecutionTemplate createTransactionalExecutionTemplate(Connection connection, boolean rollbackOnException) {
+        ExecutionTemplate delegate = super.createTransactionalExecutionTemplate(connection, rollbackOnException);
+        int[] knobs = OCC_RETRY_KNOBS.getOrDefault(connection, DEFAULT_OCC_RETRY_KNOBS);
+        return new DSQLExecutionTemplate(delegate, knobs[0], maxRetryDelayMillis(knobs[1]));
+    }
+
+    /** Converts the configured delay cap (seconds) to milliseconds, floored at {@link #MIN_RETRY_DELAY_MS}. */
+    static long maxRetryDelayMillis(int maxRetryDelaySeconds) {
+        return Math.max(MIN_RETRY_DELAY_MS, (long) maxRetryDelaySeconds * 1000L);
+    }
+
+    static int[] resolveOccRetryKnobs(Configuration configuration) {
+        if (configuration == null) {
+            return DEFAULT_OCC_RETRY_KNOBS.clone();
+        }
+        DSQLConfigurationExtension ext =
+                configuration.getPluginRegister().getPlugin(DSQLConfigurationExtension.class);
+        if (ext == null) {
+            return DEFAULT_OCC_RETRY_KNOBS.clone();
+        }
+        // The connector accepts a retry count of 0 to 100 and rejects anything outside that range;
+        // clamp so a stray config value degrades gracefully instead of failing the migration.
+        int maxRetries = Math.min(100, Math.max(0, ext.getOccMaxRetries()));
+        return new int[]{maxRetries, ext.getOccMaxRetryDelaySeconds()};
+    }
+
+    /**
+     * Wraps the base SQL-script executor factory so that, when {@code flyway.dsql.awaitAsyncIndexes}
+     * is enabled, a migration's {@code CREATE INDEX ASYNC} blocks until the index build completes.
+     * DSQL builds indexes in the background and returns a runtime {@code job_id}; static SQL cannot
+     * thread that id into {@code sys.wait_for_job}, so the wait is issued here. Off by default. See
+     * {@link DSQLSqlScriptExecutor}.
+     */
+    @Override
+    public SqlScriptExecutorFactory createSqlScriptExecutorFactory(
+            JdbcConnectionFactory jdbcConnectionFactory,
+            CallbackExecutor callbackExecutor,
+            StatementInterceptor statementInterceptor) {
+        SqlScriptExecutorFactory delegate = super.createSqlScriptExecutorFactory(
+                jdbcConnectionFactory, callbackExecutor, statementInterceptor);
+        return new DSQLSqlScriptExecutorFactory(delegate);
+    }
+
+    @Override
+    public Parser createParser(Configuration configuration, ResourceProvider resourceProvider,
+                               ParsingContext parsingContext) {
+        return new DSQLParser(configuration, parsingContext);
+    }
+
+    @Override
+    public String getPluginVersion(Configuration config) {
+        return DSQLDatabaseExtension.readVersion();
+    }
+}

--- a/flyway-database-dsql/src/main/java/org/flywaydb/community/database/dsql/DSQLDatabaseType.java
+++ b/flyway-database-dsql/src/main/java/org/flywaydb/community/database/dsql/DSQLDatabaseType.java
@@ -1,0 +1,202 @@
+/*-
+ * ========================LICENSE_START=================================
+ * flyway-database-dsql
+ * ========================================================================
+ * Copyright (C) 2010 - 2026 Red Gate Software Ltd
+ * ========================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+package org.flywaydb.community.database.dsql;
+
+import org.flywaydb.community.database.DSQLDatabaseExtension;
+import org.flywaydb.core.api.ResourceProvider;
+import org.flywaydb.core.api.configuration.Configuration;
+import org.flywaydb.core.internal.callback.CallbackExecutor;
+import org.flywaydb.core.internal.database.base.CommunityDatabaseType;
+import org.flywaydb.core.internal.database.base.Database;
+import org.flywaydb.core.internal.jdbc.ExecutionTemplate;
+import org.flywaydb.core.internal.jdbc.JdbcConnectionFactory;
+import org.flywaydb.core.internal.jdbc.StatementInterceptor;
+import org.flywaydb.core.internal.parser.Parser;
+import org.flywaydb.core.internal.parser.ParsingContext;
+import org.flywaydb.core.internal.sqlscript.SqlScriptExecutorFactory;
+import org.flywaydb.database.postgresql.PostgreSQLDatabaseType;
+import software.amazon.dsql.jdbc.OCCRetryConfig;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.sql.Connection;
+import java.sql.SQLException;
+
+/**
+ * Flyway database type for Amazon Aurora DSQL.
+ *
+ * <p>Extends PostgreSQL support to handle {@code jdbc:aws-dsql:} URLs and DSQL endpoints.
+ * The Aurora DSQL JDBC connector transforms {@code jdbc:aws-dsql:postgresql://} URLs to
+ * {@code jdbc:postgresql://} internally, so DSQL is detected by both the URL prefix and the
+ * endpoint host pattern ({@code .dsql.} for public endpoints, {@code .dsql-} for PrivateLink).
+ */
+public class DSQLDatabaseType extends PostgreSQLDatabaseType implements CommunityDatabaseType {
+
+    private static final String DSQL_PUBLIC_PATTERN = ".dsql.";
+    private static final String DSQL_PRIVATELINK_PATTERN = ".dsql-";
+    private static final int DEFAULT_MAX_RETRIES = 0;
+    private static final int DEFAULT_MAX_RETRY_DELAY_SECONDS = 5;
+    private static final long MIN_RETRY_DELAY_MS = 100L;
+
+    // DatabaseType is a JVM-global singleton resolved from a static registry, and the commit-wrapping
+    // seam (createTransactionalExecutionTemplate) receives no Configuration. Flyway runs a migration
+    // synchronously on one thread, so we stash the per-run OCC retry knobs (resolved in createDatabase)
+    // in a ThreadLocal and read them back when building the transactional template on the same thread.
+    private static final ThreadLocal<int[]> OCC_RETRY_KNOBS =
+            ThreadLocal.withInitial(() -> new int[]{DEFAULT_MAX_RETRIES, DEFAULT_MAX_RETRY_DELAY_SECONDS});
+
+    @Override
+    public String getName() {
+        return "Aurora DSQL";
+    }
+
+    @Override
+    public boolean handlesJDBCUrl(String url) {
+        if (url.startsWith("jdbc:aws-dsql:")) {
+            return true;
+        }
+        return url.startsWith("jdbc:postgresql://") && isDsqlHost(url);
+    }
+
+    /**
+     * Matches the DSQL endpoint pattern against the URL's host only, so a {@code .dsql.} appearing
+     * elsewhere (database name, query parameter) cannot misclassify a plain PostgreSQL URL as DSQL.
+     */
+    private static boolean isDsqlHost(String jdbcUrl) {
+        String host = extractHost(jdbcUrl);
+        return host != null
+                && (host.contains(DSQL_PUBLIC_PATTERN) || host.contains(DSQL_PRIVATELINK_PATTERN));
+    }
+
+    /** Extracts the host from a {@code jdbc:...} URL, or null if it cannot be parsed. */
+    private static String extractHost(String jdbcUrl) {
+        int scheme = jdbcUrl.indexOf("://");
+        if (scheme < 0) {
+            return null;
+        }
+        try {
+            // Strip the "jdbc:" prefix so java.net.URI sees a single, parseable scheme.
+            URI uri = new URI(jdbcUrl.substring(jdbcUrl.indexOf(':') + 1));
+            return uri.getHost();
+        } catch (URISyntaxException e) {
+            return null;
+        }
+    }
+
+    @Override
+    public int getPriority() {
+        // Higher than PostgreSQL (0) so DSQL URLs are matched first.
+        return 1;
+    }
+
+    @Override
+    public boolean handlesDatabaseProductNameAndVersion(String databaseProductName,
+                                                        String databaseProductVersion,
+                                                        Connection connection) {
+        try {
+            String url = connection.getMetaData().getURL();
+            return url != null && isDsqlHost(url);
+        } catch (SQLException e) {
+            return false;
+        }
+    }
+
+    @Override
+    public String getDriverClass(String url, ClassLoader classLoader) {
+        if (url.startsWith("jdbc:aws-dsql:")) {
+            return "software.amazon.dsql.jdbc.DSQLConnector";
+        }
+        return "org.postgresql.Driver";
+    }
+
+    @Override
+    public Database createDatabase(Configuration configuration,
+                                   JdbcConnectionFactory jdbcConnectionFactory,
+                                   StatementInterceptor statementInterceptor) {
+        OCC_RETRY_KNOBS.set(resolveOccRetryKnobs(configuration));
+        return new DSQLDatabase(configuration, jdbcConnectionFactory, statementInterceptor);
+    }
+
+    /**
+     * Wraps the base transactional template so a commit-time OCC conflict retries the whole
+     * migration transaction. This is the only Flyway seam that spans {@code connection.commit()},
+     * where DSQL surfaces {@code OC000}/{@code OC001}/{@code 40001}.
+     */
+    @Override
+    public ExecutionTemplate createTransactionalExecutionTemplate(Connection connection, boolean rollbackOnException) {
+        ExecutionTemplate delegate = super.createTransactionalExecutionTemplate(connection, rollbackOnException);
+        int[] knobs = OCC_RETRY_KNOBS.get();
+        // Override the connector's documented defaults (3 retries / 5s) with the configured knobs;
+        // baseDelay/multiplier/jitter keep the connector defaults so the contract stays shared.
+        OCCRetryConfig retryConfig = OCCRetryConfig.builder()
+                .maxRetries(knobs[0])
+                .maxDelayMs(maxRetryDelayMillis(knobs[1]))
+                .build();
+        return new DSQLExecutionTemplate(delegate, retryConfig);
+    }
+
+    /** Converts the configured delay cap (seconds) to milliseconds, floored at {@link #MIN_RETRY_DELAY_MS}. */
+    static long maxRetryDelayMillis(int maxRetryDelaySeconds) {
+        return Math.max(MIN_RETRY_DELAY_MS, (long) maxRetryDelaySeconds * 1000L);
+    }
+
+    static int[] resolveOccRetryKnobs(Configuration configuration) {
+        if (configuration == null) {
+            return new int[]{DEFAULT_MAX_RETRIES, DEFAULT_MAX_RETRY_DELAY_SECONDS};
+        }
+        DSQLConfigurationExtension ext =
+                configuration.getPluginRegister().getPlugin(DSQLConfigurationExtension.class);
+        if (ext == null) {
+            return new int[]{DEFAULT_MAX_RETRIES, DEFAULT_MAX_RETRY_DELAY_SECONDS};
+        }
+        // OCCRetryConfig.build() rejects maxRetries outside [0, 100]; clamp so a stray config value
+        // degrades gracefully instead of failing the migration.
+        int maxRetries = Math.min(100, Math.max(0, ext.getOccMaxRetries()));
+        return new int[]{maxRetries, ext.getOccMaxRetryDelaySeconds()};
+    }
+
+    /**
+     * Wraps the base SQL-script executor factory so that, when {@code flyway.dsql.awaitAsyncIndexes}
+     * is enabled, a migration's {@code CREATE INDEX ASYNC} blocks until the index build completes.
+     * DSQL builds indexes in the background and returns a runtime {@code job_id}; static SQL cannot
+     * thread that id into {@code sys.wait_for_job}, so the wait is issued here. Off by default. See
+     * {@link DSQLSqlScriptExecutor}.
+     */
+    @Override
+    public SqlScriptExecutorFactory createSqlScriptExecutorFactory(
+            JdbcConnectionFactory jdbcConnectionFactory,
+            CallbackExecutor callbackExecutor,
+            StatementInterceptor statementInterceptor) {
+        SqlScriptExecutorFactory delegate = super.createSqlScriptExecutorFactory(
+                jdbcConnectionFactory, callbackExecutor, statementInterceptor);
+        return new DSQLSqlScriptExecutorFactory(delegate);
+    }
+
+    @Override
+    public Parser createParser(Configuration configuration, ResourceProvider resourceProvider,
+                               ParsingContext parsingContext) {
+        return new DSQLParser(configuration, parsingContext);
+    }
+
+    @Override
+    public String getPluginVersion(Configuration config) {
+        return DSQLDatabaseExtension.readVersion();
+    }
+}

--- a/flyway-database-dsql/src/main/java/org/flywaydb/community/database/dsql/DSQLExecutionTemplate.java
+++ b/flyway-database-dsql/src/main/java/org/flywaydb/community/database/dsql/DSQLExecutionTemplate.java
@@ -1,0 +1,108 @@
+/*-
+ * ========================LICENSE_START=================================
+ * flyway-database-dsql
+ * ========================================================================
+ * Copyright (C) 2010 - 2026 Red Gate Software Ltd
+ * ========================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+package org.flywaydb.community.database.dsql;
+
+import lombok.CustomLog;
+import org.flywaydb.core.api.FlywayException;
+import org.flywaydb.core.internal.jdbc.ExecutionTemplate;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * Retries a whole migration transaction on an Aurora DSQL OCC conflict.
+ *
+ * <p>DSQL detects conflicts at commit time ({@code OC000}/{@code OC001}/{@code 40001}). Flyway
+ * runs each migration inside an {@link ExecutionTemplate} whose {@code execute} calls
+ * {@code connection.commit()} <em>after</em> the callback, so a conflict surfaces at the
+ * transaction boundary — not inside a single statement. This decorator wraps the delegate
+ * transactional template and retries the entire callback (statements + commit) when the
+ * failure carries an OCC SQLSTATE. A conflicting transaction is rolled back before the retry, so
+ * nothing was committed to replay; SQL migrations are re-parsed and re-run cleanly. (A Java
+ * migration with external side effects would re-execute those side effects on each attempt.)
+ *
+ * <p>Replaying the callback also replays Flyway's in-memory bookkeeping: a migration that commits
+ * only after a retry can appear more than once in the reported {@code MigrateResult}. The
+ * migration's own statements roll back with the failed commit, but the schema-history insert runs
+ * on the auto-commit main connection and survives, so a retried migration leaves a duplicate
+ * history row that {@link DSQLConnection} reconciles afterward.
+ *
+ * <p>This wraps every transactional commit for the DSQL type, not just migrations (e.g.
+ * schema-history table creation), so OCC conflicts on those commits are retried here too.
+ *
+ * <p>The schedule mirrors the connector's {@code OCCRetryConfig} defaults (100ms base delay, x2
+ * multiplier, 25% jitter); the {@code dsql} configuration supplies the retry count and delay cap
+ * (the count defaults to 0, so OCC retry is off unless {@code flyway.dsql.occMaxRetries} is set to a
+ * positive value). Held here rather than in {@code OCCRetryConfig} so this decorator does not need
+ * the connector on the classpath — see {@link DSQLOccErrors}.
+ */
+@CustomLog
+class DSQLExecutionTemplate implements ExecutionTemplate {
+
+    private static final long BASE_DELAY_MS = 100L;
+    private static final double MULTIPLIER = 2.0d;
+    private static final double JITTER_FACTOR = 0.25d;
+
+    private final ExecutionTemplate delegate;
+    private final int maxRetries;
+    private final long maxDelayMs;
+
+    DSQLExecutionTemplate(ExecutionTemplate delegate, int maxRetries, long maxDelayMs) {
+        this.delegate = delegate;
+        this.maxRetries = maxRetries;
+        this.maxDelayMs = maxDelayMs;
+    }
+
+    @Override
+    public <T> T execute(Callable<T> callback) {
+        int attempt = 0;
+        while (true) {
+            try {
+                return delegate.execute(callback);
+            } catch (RuntimeException e) {
+                if (!DSQLOccErrors.isOccError(e) || attempt >= maxRetries) {
+                    throw e;
+                }
+                sleep(backoff(attempt));
+                attempt++;
+                LOG.info("Retrying migration transaction after Aurora DSQL OCC conflict (attempt "
+                        + attempt + " of " + maxRetries + ")");
+            }
+        }
+    }
+
+    // Mirrors the connector's OCCRetry.calculateBackoff (package-private there, so it cannot be
+    // reused): exponential base delay capped at maxDelayMs, plus up to JITTER_FACTOR of that delay.
+    private long backoff(int attempt) {
+        int exponent = Math.min(attempt, 31);
+        double delay = Math.min(BASE_DELAY_MS * Math.pow(MULTIPLIER, exponent), maxDelayMs);
+        double jitter = delay * ThreadLocalRandom.current().nextDouble() * JITTER_FACTOR;
+        return (long) (delay + jitter);
+    }
+
+    private void sleep(long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+            throw new FlywayException("Aurora DSQL OCC retry interrupted", ie);
+        }
+    }
+}

--- a/flyway-database-dsql/src/main/java/org/flywaydb/community/database/dsql/DSQLExecutionTemplate.java
+++ b/flyway-database-dsql/src/main/java/org/flywaydb/community/database/dsql/DSQLExecutionTemplate.java
@@ -1,0 +1,106 @@
+/*-
+ * ========================LICENSE_START=================================
+ * flyway-database-dsql
+ * ========================================================================
+ * Copyright (C) 2010 - 2026 Red Gate Software Ltd
+ * ========================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+package org.flywaydb.community.database.dsql;
+
+import org.flywaydb.core.api.FlywayException;
+import org.flywaydb.core.internal.jdbc.ExecutionTemplate;
+import software.amazon.dsql.jdbc.OCCRetryConfig;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.logging.Logger;
+
+/**
+ * Retries a whole migration transaction on an Aurora DSQL OCC conflict.
+ *
+ * <p>DSQL detects conflicts at commit time ({@code OC000}/{@code OC001}/{@code 40001}). Flyway
+ * runs each migration inside an {@link ExecutionTemplate} whose {@code execute} calls
+ * {@code connection.commit()} <em>after</em> the callback, so a conflict surfaces at the
+ * transaction boundary — not inside a single statement. This decorator wraps the delegate
+ * transactional template and retries the entire callback (statements + commit) when the
+ * failure carries an OCC SQLSTATE. A conflicting transaction is rolled back before the retry, so
+ * nothing was committed to replay; SQL migrations are re-parsed and re-run cleanly. (A Java
+ * migration with external side effects would re-execute those side effects on each attempt.)
+ *
+ * <p>Replaying the callback also replays Flyway's in-memory bookkeeping: a migration that commits
+ * only after a retry can appear more than once in the reported {@code MigrateResult}. The
+ * migration's own statements roll back with the failed commit, but the schema-history insert runs
+ * on the auto-commit main connection and survives, so a retried migration leaves a duplicate
+ * history row that {@link DSQLConnection} reconciles afterward.
+ *
+ * <p>This wraps every transactional commit for the DSQL type, not just migrations (e.g.
+ * schema-history table creation), so OCC conflicts on those commits are retried here too.
+ *
+ * <p>The retry knobs (count, base/max delay, multiplier, jitter) come from the Aurora DSQL JDBC
+ * connector's {@link OCCRetryConfig} so the contract stays in sync with the connector rather than
+ * being re-declared here; the {@code dsql} configuration supplies the count and cap as explicit
+ * overrides on top of the connector defaults (the count defaults to 0, so OCC retry is off unless
+ * {@code flyway.dsql.occMaxRetries} is set to a positive value).
+ */
+class DSQLExecutionTemplate implements ExecutionTemplate {
+
+    private static final Logger LOG = Logger.getLogger(DSQLExecutionTemplate.class.getName());
+
+    private final ExecutionTemplate delegate;
+    private final OCCRetryConfig retryConfig;
+
+    DSQLExecutionTemplate(ExecutionTemplate delegate, OCCRetryConfig retryConfig) {
+        this.delegate = delegate;
+        this.retryConfig = retryConfig;
+    }
+
+    @Override
+    public <T> T execute(Callable<T> callback) {
+        int maxRetries = retryConfig.getMaxRetries();
+        int attempt = 0;
+        while (true) {
+            try {
+                return delegate.execute(callback);
+            } catch (RuntimeException e) {
+                if (!DSQLOccErrors.isOccError(e) || attempt >= maxRetries) {
+                    throw e;
+                }
+                sleep(backoff(attempt));
+                attempt++;
+                LOG.info("Retrying migration transaction after Aurora DSQL OCC conflict (attempt "
+                        + attempt + " of " + maxRetries + ")");
+            }
+        }
+    }
+
+    // Mirrors the connector's OCCRetry.calculateBackoff (package-private there, so it cannot be
+    // reused): exponential base delay capped at maxDelayMs, plus up to jitterFactor of that delay.
+    private long backoff(int attempt) {
+        int exponent = Math.min(attempt, 31);
+        double delay = Math.min(retryConfig.getBaseDelayMs() * Math.pow(retryConfig.getMultiplier(), exponent),
+                retryConfig.getMaxDelayMs());
+        double jitter = delay * ThreadLocalRandom.current().nextDouble() * retryConfig.getJitterFactor();
+        return (long) (delay + jitter);
+    }
+
+    private void sleep(long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+            throw new FlywayException("Aurora DSQL OCC retry interrupted", ie);
+        }
+    }
+}

--- a/flyway-database-dsql/src/main/java/org/flywaydb/community/database/dsql/DSQLOccErrors.java
+++ b/flyway-database-dsql/src/main/java/org/flywaydb/community/database/dsql/DSQLOccErrors.java
@@ -1,0 +1,79 @@
+/*-
+ * ========================LICENSE_START=================================
+ * flyway-database-dsql
+ * ========================================================================
+ * Copyright (C) 2010 - 2026 Red Gate Software Ltd
+ * ========================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+package org.flywaydb.community.database.dsql;
+
+import java.sql.SQLException;
+
+/**
+ * Detects Aurora DSQL optimistic-concurrency-control (OCC) conflicts.
+ *
+ * <p>DSQL reports a conflict as SQLSTATE {@code 40001} carrying an OC code in the message —
+ * {@code OC000} for data, {@code OC001} for catalog/schema — and also raises those codes as the
+ * SQLSTATE itself. All three forms are matched here rather than delegated to the connector's
+ * {@code OCCRetry.isOCCError}, so retry also works on {@code jdbc:postgresql://} endpoints where the
+ * connector is not the driver and need not be on the classpath.
+ *
+ * <p>Walks the cause / next-exception chain: at the transaction-template layer the conflict arrives
+ * wrapped in a {@code FlywaySqlException}, not a bare {@link SQLException}.
+ */
+final class DSQLOccErrors {
+
+    private static final String OCC_DATA_CONFLICT = "OC000";
+    private static final String OCC_CATALOG_CONFLICT = "OC001";
+    private static final String OCC_SERIALIZATION = "40001";
+
+    private DSQLOccErrors() {
+    }
+
+    /**
+     * Returns true if the given exception, or anything in its cause / next-exception
+     * chain, is an Aurora DSQL OCC conflict.
+     */
+    static boolean isOccError(Throwable throwable) {
+        Throwable current = throwable;
+        while (current != null) {
+            if (current instanceof SQLException) {
+                SQLException sqlException = (SQLException) current;
+                if (isOccSqlException(sqlException)) {
+                    return true;
+                }
+                SQLException next = sqlException.getNextException();
+                if (next != null && isOccError(next)) {
+                    return true;
+                }
+            }
+            current = current.getCause();
+        }
+        return false;
+    }
+
+    private static boolean isOccSqlException(SQLException e) {
+        String sqlState = e.getSQLState();
+        if (OCC_DATA_CONFLICT.equals(sqlState) || OCC_CATALOG_CONFLICT.equals(sqlState)) {
+            return true;
+        }
+        String message = e.getMessage();
+        if (message != null
+                && (message.contains(OCC_DATA_CONFLICT) || message.contains(OCC_CATALOG_CONFLICT))) {
+            return true;
+        }
+        return OCC_SERIALIZATION.equals(sqlState);
+    }
+}

--- a/flyway-database-dsql/src/main/java/org/flywaydb/community/database/dsql/DSQLOccErrors.java
+++ b/flyway-database-dsql/src/main/java/org/flywaydb/community/database/dsql/DSQLOccErrors.java
@@ -1,0 +1,62 @@
+/*-
+ * ========================LICENSE_START=================================
+ * flyway-database-dsql
+ * ========================================================================
+ * Copyright (C) 2010 - 2026 Red Gate Software Ltd
+ * ========================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+package org.flywaydb.community.database.dsql;
+
+import software.amazon.dsql.jdbc.OCCRetry;
+
+import java.sql.SQLException;
+
+/**
+ * Detects Aurora DSQL optimistic-concurrency-control (OCC) conflicts.
+ *
+ * <p>The SQLSTATE contract ({@code OC000} data conflict, {@code OC001} catalog/schema conflict,
+ * {@code 40001} serialization) is owned by the connector's {@link OCCRetry#isOCCError(SQLException)}
+ * and delegated to here so the two never drift. What this class adds is Flyway-specific: the
+ * connector inspects a single raw {@link SQLException}, but at the transaction-template layer the
+ * conflict arrives wrapped in a {@code FlywaySqlException} (not a {@code SQLException}), so we walk
+ * the cause / next-exception chain and delegate each {@link SQLException} node to the connector.
+ */
+final class DSQLOccErrors {
+
+    private DSQLOccErrors() {
+    }
+
+    /**
+     * Returns true if the given exception, or anything in its cause / next-exception
+     * chain, is an Aurora DSQL OCC conflict.
+     */
+    static boolean isOccError(Throwable throwable) {
+        Throwable current = throwable;
+        while (current != null) {
+            if (current instanceof SQLException) {
+                SQLException sqlException = (SQLException) current;
+                if (OCCRetry.isOCCError(sqlException)) {
+                    return true;
+                }
+                SQLException next = sqlException.getNextException();
+                if (next != null && isOccError(next)) {
+                    return true;
+                }
+            }
+            current = current.getCause();
+        }
+        return false;
+    }
+}

--- a/flyway-database-dsql/src/main/java/org/flywaydb/community/database/dsql/DSQLParser.java
+++ b/flyway-database-dsql/src/main/java/org/flywaydb/community/database/dsql/DSQLParser.java
@@ -1,0 +1,30 @@
+/*-
+ * ========================LICENSE_START=================================
+ * flyway-database-dsql
+ * ========================================================================
+ * Copyright (C) 2010 - 2026 Red Gate Software Ltd
+ * ========================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+package org.flywaydb.community.database.dsql;
+
+import org.flywaydb.core.api.configuration.Configuration;
+import org.flywaydb.core.internal.parser.ParsingContext;
+import org.flywaydb.database.postgresql.PostgreSQLParser;
+
+public class DSQLParser extends PostgreSQLParser {
+    public DSQLParser(Configuration configuration, ParsingContext parsingContext) {
+        super(configuration, parsingContext);
+    }
+}

--- a/flyway-database-dsql/src/main/java/org/flywaydb/community/database/dsql/DSQLSchema.java
+++ b/flyway-database-dsql/src/main/java/org/flywaydb/community/database/dsql/DSQLSchema.java
@@ -1,0 +1,93 @@
+/*-
+ * ========================LICENSE_START=================================
+ * flyway-database-dsql
+ * ========================================================================
+ * Copyright (C) 2010 - 2026 Red Gate Software Ltd
+ * ========================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+package org.flywaydb.community.database.dsql;
+
+import lombok.CustomLog;
+import org.flywaydb.core.internal.database.base.Table;
+import org.flywaydb.core.internal.jdbc.JdbcTemplate;
+import org.flywaydb.database.postgresql.PostgreSQLSchema;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Aurora DSQL schema implementation for Flyway.
+ *
+ * <p>Aurora DSQL allows only one DDL statement per transaction, so {@link #doClean()}
+ * drops views then tables one at a time with autocommit enabled.
+ */
+@CustomLog
+public class DSQLSchema extends PostgreSQLSchema {
+
+    public DSQLSchema(JdbcTemplate jdbcTemplate, DSQLDatabase database, String name) {
+        super(jdbcTemplate, database, name);
+    }
+
+    @Override
+    public Table getTable(String tableName) {
+        return new DSQLTable(jdbcTemplate, (DSQLDatabase) database, this, tableName);
+    }
+
+    @Override
+    protected void doClean() throws SQLException {
+        Connection conn = jdbcTemplate.getConnection();
+        boolean originalAutoCommit = conn.getAutoCommit();
+        try {
+            conn.setAutoCommit(true);
+
+            for (String view : getViews(conn)) {
+                String dropSql = "DROP VIEW IF EXISTS " + database.quote(name, view);
+                LOG.debug("Dropping view: " + dropSql);
+                try (Statement stmt = conn.createStatement()) {
+                    stmt.execute(dropSql);
+                }
+            }
+
+            for (Table table : allTables()) {
+                String dropSql = "DROP TABLE IF EXISTS " + database.quote(name, table.getName());
+                LOG.debug("Dropping table: " + dropSql);
+                try (Statement stmt = conn.createStatement()) {
+                    stmt.execute(dropSql);
+                }
+            }
+        } finally {
+            conn.setAutoCommit(originalAutoCommit);
+        }
+    }
+
+    private List<String> getViews(Connection conn) throws SQLException {
+        List<String> views = new ArrayList<>();
+        String sql = "SELECT table_name FROM information_schema.views WHERE table_schema = ?";
+        try (PreparedStatement pstmt = conn.prepareStatement(sql)) {
+            pstmt.setString(1, name);
+            try (ResultSet rs = pstmt.executeQuery()) {
+                while (rs.next()) {
+                    views.add(rs.getString(1));
+                }
+            }
+        }
+        return views;
+    }
+}

--- a/flyway-database-dsql/src/main/java/org/flywaydb/community/database/dsql/DSQLSchema.java
+++ b/flyway-database-dsql/src/main/java/org/flywaydb/community/database/dsql/DSQLSchema.java
@@ -1,0 +1,94 @@
+/*-
+ * ========================LICENSE_START=================================
+ * flyway-database-dsql
+ * ========================================================================
+ * Copyright (C) 2010 - 2026 Red Gate Software Ltd
+ * ========================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+package org.flywaydb.community.database.dsql;
+
+import org.flywaydb.core.internal.database.base.Table;
+import org.flywaydb.core.internal.jdbc.JdbcTemplate;
+import org.flywaydb.database.postgresql.PostgreSQLSchema;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Logger;
+
+/**
+ * Aurora DSQL schema implementation for Flyway.
+ *
+ * <p>Aurora DSQL allows only one DDL statement per transaction, so {@link #doClean()}
+ * drops views then tables one at a time with autocommit enabled.
+ */
+public class DSQLSchema extends PostgreSQLSchema {
+
+    private static final Logger LOG = Logger.getLogger(DSQLSchema.class.getName());
+
+    public DSQLSchema(JdbcTemplate jdbcTemplate, DSQLDatabase database, String name) {
+        super(jdbcTemplate, database, name);
+    }
+
+    @Override
+    public Table getTable(String tableName) {
+        return new DSQLTable(jdbcTemplate, (DSQLDatabase) database, this, tableName);
+    }
+
+    @Override
+    protected void doClean() throws SQLException {
+        Connection conn = jdbcTemplate.getConnection();
+        boolean originalAutoCommit = conn.getAutoCommit();
+        try {
+            conn.setAutoCommit(true);
+
+            for (String view : getViews(conn)) {
+                String dropSql = "DROP VIEW IF EXISTS " + database.quote(name, view);
+                LOG.fine("Dropping view: " + dropSql);
+                try (Statement stmt = conn.createStatement()) {
+                    stmt.execute(dropSql);
+                }
+            }
+
+            for (Table table : allTables()) {
+                String dropSql = "DROP TABLE IF EXISTS " + database.quote(name, table.getName());
+                LOG.fine("Dropping table: " + dropSql);
+                try (Statement stmt = conn.createStatement()) {
+                    stmt.execute(dropSql);
+                }
+            }
+        } finally {
+            conn.setAutoCommit(originalAutoCommit);
+        }
+    }
+
+    private List<String> getViews(Connection conn) throws SQLException {
+        List<String> views = new ArrayList<>();
+        String sql = "SELECT table_name FROM information_schema.views WHERE table_schema = ?";
+        try (PreparedStatement pstmt = conn.prepareStatement(sql)) {
+            pstmt.setString(1, name);
+            try (ResultSet rs = pstmt.executeQuery()) {
+                while (rs.next()) {
+                    views.add(rs.getString(1));
+                }
+            }
+        }
+        return views;
+    }
+}

--- a/flyway-database-dsql/src/main/java/org/flywaydb/community/database/dsql/DSQLSqlScriptExecutor.java
+++ b/flyway-database-dsql/src/main/java/org/flywaydb/community/database/dsql/DSQLSqlScriptExecutor.java
@@ -1,0 +1,262 @@
+/*-
+ * ========================LICENSE_START=================================
+ * flyway-database-dsql
+ * ========================================================================
+ * Copyright (C) 2010 - 2026 Red Gate Software Ltd
+ * ========================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+package org.flywaydb.community.database.dsql;
+
+import lombok.CustomLog;
+import org.flywaydb.core.api.FlywayException;
+import org.flywaydb.core.api.configuration.Configuration;
+import org.flywaydb.core.internal.jdbc.Result;
+import org.flywaydb.core.internal.jdbc.Results;
+import org.flywaydb.core.internal.sqlscript.SqlScript;
+import org.flywaydb.core.internal.sqlscript.SqlScriptExecutor;
+
+import java.sql.CallableStatement;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.regex.Pattern;
+
+/**
+ * Blocks until an Aurora DSQL {@code CREATE INDEX ASYNC} build completes.
+ *
+ * <p>DSQL has no synchronous index creation: {@code CREATE INDEX ASYNC} returns a runtime
+ * {@code job_id} and builds the index in the background. Static SQL cannot thread that id into
+ * the required {@code CALL sys.wait_for_job('<job_id>')}, so a plain SQL migration reports
+ * success while the index is still building. When {@code flyway.dsql.awaitAsyncIndexes} is true,
+ * this decorator runs the delegate executor, then for every result that is a
+ * {@code CREATE INDEX ASYNC} carrying a {@code job_id} issues the wait on the same connection
+ * before returning — so a later migration step sees a built index. Per the DSQL docs (and verified
+ * against a live cluster), a build that does not succeed does not raise: {@code sys.wait_for_job}
+ * returns a single boolean row that is {@code false} when the build failed or the wait timed out,
+ * so the outcome is detected by inspecting that boolean and the migration is failed explicitly (a
+ * raised {@link SQLException} is still handled as a fallback).
+ *
+ * <p>A failed build leaves an {@code INVALID} index in place (the DSQL docs recommend dropping and
+ * recreating it); the migration fails without dropping it, since a timed-out wait may front a build
+ * that still succeeds. A rerun must drop it first — {@code IF NOT EXISTS} can silently accept the
+ * {@code INVALID} index.
+ *
+ * <p>Opt-in, off by default: the wait fires only when {@code flyway.dsql.awaitAsyncIndexes} is
+ * enabled. When disabled (the default), the decorator is a pass-through that returns the
+ * delegate's results untouched.
+ *
+ * <p>SQL migrations only: Java migrations run against {@code context.getConnection()} directly and
+ * bypass this executor, managing their own waiting.
+ */
+@CustomLog
+class DSQLSqlScriptExecutor implements SqlScriptExecutor {
+
+    // Matches a CREATE INDEX ... ASYNC statement (tolerant of UNIQUE, whitespace). The statement
+    // text is passed through stripComments() first, which replaces every comment with a space, so
+    // comments Flyway keeps in Result.sql() (leading, or between the keywords) cannot hide a match.
+    private static final Pattern CREATE_INDEX_ASYNC = Pattern.compile(
+            "^\\s*CREATE\\s+(UNIQUE\\s+)?INDEX\\s+ASYNC\\b", Pattern.CASE_INSENSITIVE);
+
+    private static final String JOB_ID_COLUMN = "job_id";
+
+    private final SqlScriptExecutor delegate;
+    private final Connection connection;
+
+    DSQLSqlScriptExecutor(SqlScriptExecutor delegate, Connection connection) {
+        this.delegate = delegate;
+        this.connection = connection;
+    }
+
+    @Override
+    public List<Results> execute(SqlScript sqlScript, Configuration configuration) {
+        List<Results> resultsList = delegate.execute(sqlScript, configuration);
+        if (!awaitAsyncIndexesEnabled(configuration)) {
+            return resultsList;
+        }
+        for (Results results : resultsList) {
+            // Flyway 11.9 adds a null Results when flushing an empty batch around an unbatchable
+            // statement (CREATE INDEX ASYNC under flyway.batch=true).
+            if (results == null) {
+                continue;
+            }
+            for (Result result : results.getResults()) {
+                String jobId = asyncIndexJobId(result);
+                if (jobId != null) {
+                    waitForJob(jobId);
+                }
+            }
+        }
+        return resultsList;
+    }
+
+    /**
+     * Whether the opt-in async-index wait is enabled for this run. Reads the {@code dsql} extension
+     * from the {@link Configuration} handed to this call; null-guarded to {@code false} so a missing
+     * configuration or extension leaves the decorator as a pass-through.
+     */
+    private static boolean awaitAsyncIndexesEnabled(Configuration configuration) {
+        if (configuration == null || configuration.getPluginRegister() == null) {
+            return false;
+        }
+        DSQLConfigurationExtension ext =
+                configuration.getPluginRegister().getPlugin(DSQLConfigurationExtension.class);
+        return ext != null && ext.isAwaitAsyncIndexes();
+    }
+
+    /** Returns the async-index {@code job_id} for this result, or null if it is not one. */
+    private static String asyncIndexJobId(Result result) {
+        String sql = stripComments(result.sql());
+        if (sql == null || !CREATE_INDEX_ASYNC.matcher(sql).find()) {
+            return null;
+        }
+        List<String> columns = result.columns();
+        List<List<String>> data = result.data();
+        if (columns == null || data == null || data.isEmpty()) {
+            throw missingJobId(sql);
+        }
+        int idx = -1;
+        for (int i = 0; i < columns.size(); i++) {
+            if (JOB_ID_COLUMN.equalsIgnoreCase(columns.get(i))) {
+                idx = i;
+                break;
+            }
+        }
+        List<String> firstRow = data.get(0);
+        if (idx < 0 || idx >= firstRow.size()) {
+            throw missingJobId(sql);
+        }
+        String jobId = firstRow.get(idx);
+        if (jobId == null || jobId.isEmpty()) {
+            throw missingJobId(sql);
+        }
+        return jobId;
+    }
+
+    /**
+     * Fails the migration when an async-index statement matched but no {@code job_id} was
+     * capturable: with awaitAsyncIndexes enabled the wait must not be silently skipped, since a
+     * later step could run against an unbuilt index.
+     */
+    private static FlywayException missingJobId(String sql) {
+        return new FlywayException("Aurora DSQL async index build could not be awaited: "
+                + "awaitAsyncIndexes is enabled and this statement matched CREATE INDEX ASYNC, but "
+                + "no job_id was found in its result: " + sql);
+    }
+
+    /**
+     * Replaces every line ({@code -- ...}) and block ({@code /}{@code * ... *}{@code /}, nested)
+     * comment with a single space, so a comment cannot hide the {@code CREATE INDEX ASYNC} keywords
+     * whether it precedes them or sits between them. Flyway retains such comments in
+     * {@link Result#sql()}. Each comment becomes a space (not nothing) to keep keyword boundaries.
+     */
+    private static String stripComments(String sql) {
+        if (sql == null) {
+            return null;
+        }
+        StringBuilder out = new StringBuilder(sql.length());
+        int i = 0;
+        int n = sql.length();
+        while (i < n) {
+            if (sql.charAt(i) == '-' && i + 1 < n && sql.charAt(i + 1) == '-') {
+                int nl = sql.indexOf('\n', i + 2);
+                i = (nl < 0) ? n : nl + 1;
+                out.append(' ');
+            } else if (sql.charAt(i) == '/' && i + 1 < n && sql.charAt(i + 1) == '*') {
+                int depth = 1;
+                i += 2;
+                while (i < n && depth > 0) {
+                    if (sql.charAt(i) == '/' && i + 1 < n && sql.charAt(i + 1) == '*') {
+                        depth++;
+                        i += 2;
+                    } else if (sql.charAt(i) == '*' && i + 1 < n && sql.charAt(i + 1) == '/') {
+                        depth--;
+                        i += 2;
+                    } else {
+                        i++;
+                    }
+                }
+                out.append(' ');
+            } else {
+                out.append(sql.charAt(i++));
+            }
+        }
+        return out.toString().strip();
+    }
+
+    private void waitForJob(String jobId) {
+        boolean restoreAutoCommit = false;
+        RuntimeException primary = null;
+        try {
+            // sys.wait_for_job cannot run inside a transaction block. Flyway hands this executor a
+            // connection with an open transaction, so switch to autocommit (which commits the
+            // pending transaction) before the CALL, mirroring DSQLSchema.doClean(). Switching to
+            // autocommit is what commits the CREATE INDEX ASYNC that produced this job_id (it was
+            // still open in the migration's transaction), so the index exists before we wait on it.
+            // If this commit raises OCC, the DDL did not commit and DSQLExecutionTemplate replaying
+            // the migration is correct. The wait itself (a status read on sys.jobs) writes nothing,
+            // so it does not raise OCC — hence no local retry that would replay the committed DDL.
+            if (!connection.getAutoCommit()) {
+                connection.setAutoCommit(true);
+                restoreAutoCommit = true;
+            }
+            try (CallableStatement cs = connection.prepareCall("CALL sys.wait_for_job(?)")) {
+                cs.setString(1, jobId);
+                boolean hasResultSet = cs.execute();   // blocks server-side until the job finishes or times out
+                // sys.wait_for_job returns a single boolean: true = succeeded, false = the build
+                // did not succeed (it failed, or the wait timed out). A non-success does NOT raise
+                // (per the DSQL docs and verified live), so fail closed unless a true row is seen.
+                boolean succeeded = false;
+                if (hasResultSet) {
+                    try (ResultSet rs = cs.getResultSet()) {
+                        succeeded = rs.next() && rs.getBoolean(1);
+                    }
+                }
+                if (!succeeded) {
+                    throw new FlywayException(
+                            "Aurora DSQL async index build did not succeed (job_id=" + jobId
+                                    + "); it failed or the wait timed out — see sys.jobs for"
+                                    + " status and details");
+                }
+                LOG.debug("Waited for Aurora DSQL async index build, job_id=" + jobId);
+            }
+        } catch (SQLException e) {
+            primary = new FlywayException(
+                    "Aurora DSQL async index build failed or could not be awaited (job_id="
+                            + jobId + ")", e);
+        } catch (RuntimeException e) {
+            primary = e;
+        } finally {
+            if (restoreAutoCommit) {
+                try {
+                    connection.setAutoCommit(false);
+                } catch (SQLException e) {
+                    // A failed restore leaves the connection non-transactional for the rest of the
+                    // run, silently defeating rollback: never swallow it. Attach to any in-flight
+                    // error so that primary isn't masked; otherwise it becomes the failure.
+                    if (primary != null) {
+                        primary.addSuppressed(e);
+                    } else {
+                        primary = new FlywayException("Failed to restore autoCommit after Aurora "
+                                + "DSQL async index wait (job_id=" + jobId + ")", e);
+                    }
+                }
+            }
+        }
+        if (primary != null) {
+            throw primary;
+        }
+    }
+}

--- a/flyway-database-dsql/src/main/java/org/flywaydb/community/database/dsql/DSQLSqlScriptExecutor.java
+++ b/flyway-database-dsql/src/main/java/org/flywaydb/community/database/dsql/DSQLSqlScriptExecutor.java
@@ -1,0 +1,263 @@
+/*-
+ * ========================LICENSE_START=================================
+ * flyway-database-dsql
+ * ========================================================================
+ * Copyright (C) 2010 - 2026 Red Gate Software Ltd
+ * ========================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+package org.flywaydb.community.database.dsql;
+
+import org.flywaydb.core.api.FlywayException;
+import org.flywaydb.core.api.configuration.Configuration;
+import org.flywaydb.core.internal.jdbc.Result;
+import org.flywaydb.core.internal.jdbc.Results;
+import org.flywaydb.core.internal.sqlscript.SqlScript;
+import org.flywaydb.core.internal.sqlscript.SqlScriptExecutor;
+
+import java.sql.CallableStatement;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.logging.Logger;
+import java.util.regex.Pattern;
+
+/**
+ * Blocks until an Aurora DSQL {@code CREATE INDEX ASYNC} build completes.
+ *
+ * <p>DSQL has no synchronous index creation: {@code CREATE INDEX ASYNC} returns a runtime
+ * {@code job_id} and builds the index in the background. Static SQL cannot thread that id into
+ * the required {@code CALL sys.wait_for_job('<job_id>')}, so a plain SQL migration reports
+ * success while the index is still building. When {@code flyway.dsql.awaitAsyncIndexes} is true,
+ * this decorator runs the delegate executor, then for every result that is a
+ * {@code CREATE INDEX ASYNC} carrying a {@code job_id} issues the wait on the same connection
+ * before returning — so a later migration step sees a built index. Per the DSQL docs (and verified
+ * against a live cluster), a build that does not succeed does not raise: {@code sys.wait_for_job}
+ * returns a single boolean row that is {@code false} when the build failed or the wait timed out,
+ * so the outcome is detected by inspecting that boolean and the migration is failed explicitly (a
+ * raised {@link SQLException} is still handled as a fallback).
+ *
+ * <p>A failed build leaves an {@code INVALID} index in place (the DSQL docs recommend dropping and
+ * recreating it); the migration fails without dropping it, since a timed-out wait may front a build
+ * that still succeeds. A rerun must drop it first — {@code IF NOT EXISTS} can silently accept the
+ * {@code INVALID} index.
+ *
+ * <p>Opt-in, off by default: the wait fires only when {@code flyway.dsql.awaitAsyncIndexes} is
+ * enabled. When disabled (the default), the decorator is a pass-through that returns the
+ * delegate's results untouched.
+ *
+ * <p>SQL migrations only: Java migrations run against {@code context.getConnection()} directly and
+ * bypass this executor, managing their own waiting.
+ */
+class DSQLSqlScriptExecutor implements SqlScriptExecutor {
+
+    private static final Logger LOG = Logger.getLogger(DSQLSqlScriptExecutor.class.getName());
+
+    // Matches a CREATE INDEX ... ASYNC statement (tolerant of UNIQUE, whitespace). The statement
+    // text is passed through stripComments() first, which replaces every comment with a space, so
+    // comments Flyway keeps in Result.sql() (leading, or between the keywords) cannot hide a match.
+    private static final Pattern CREATE_INDEX_ASYNC = Pattern.compile(
+            "^\\s*CREATE\\s+(UNIQUE\\s+)?INDEX\\s+ASYNC\\b", Pattern.CASE_INSENSITIVE);
+
+    private static final String JOB_ID_COLUMN = "job_id";
+
+    private final SqlScriptExecutor delegate;
+    private final Connection connection;
+
+    DSQLSqlScriptExecutor(SqlScriptExecutor delegate, Connection connection) {
+        this.delegate = delegate;
+        this.connection = connection;
+    }
+
+    @Override
+    public List<Results> execute(SqlScript sqlScript, Configuration configuration) {
+        List<Results> resultsList = delegate.execute(sqlScript, configuration);
+        if (!awaitAsyncIndexesEnabled(configuration)) {
+            return resultsList;
+        }
+        for (Results results : resultsList) {
+            // Flyway 11.9 adds a null Results when flushing an empty batch around an unbatchable
+            // statement (CREATE INDEX ASYNC under flyway.batch=true).
+            if (results == null) {
+                continue;
+            }
+            for (Result result : results.getResults()) {
+                String jobId = asyncIndexJobId(result);
+                if (jobId != null) {
+                    waitForJob(jobId);
+                }
+            }
+        }
+        return resultsList;
+    }
+
+    /**
+     * Whether the opt-in async-index wait is enabled for this run. Reads the {@code dsql} extension
+     * from the {@link Configuration} handed to this call; null-guarded to {@code false} so a missing
+     * configuration or extension leaves the decorator as a pass-through.
+     */
+    private static boolean awaitAsyncIndexesEnabled(Configuration configuration) {
+        if (configuration == null || configuration.getPluginRegister() == null) {
+            return false;
+        }
+        DSQLConfigurationExtension ext =
+                configuration.getPluginRegister().getPlugin(DSQLConfigurationExtension.class);
+        return ext != null && ext.isAwaitAsyncIndexes();
+    }
+
+    /** Returns the async-index {@code job_id} for this result, or null if it is not one. */
+    private static String asyncIndexJobId(Result result) {
+        String sql = stripComments(result.sql());
+        if (sql == null || !CREATE_INDEX_ASYNC.matcher(sql).find()) {
+            return null;
+        }
+        List<String> columns = result.columns();
+        List<List<String>> data = result.data();
+        if (columns == null || data == null || data.isEmpty()) {
+            throw missingJobId(sql);
+        }
+        int idx = -1;
+        for (int i = 0; i < columns.size(); i++) {
+            if (JOB_ID_COLUMN.equalsIgnoreCase(columns.get(i))) {
+                idx = i;
+                break;
+            }
+        }
+        List<String> firstRow = data.get(0);
+        if (idx < 0 || idx >= firstRow.size()) {
+            throw missingJobId(sql);
+        }
+        String jobId = firstRow.get(idx);
+        if (jobId == null || jobId.isEmpty()) {
+            throw missingJobId(sql);
+        }
+        return jobId;
+    }
+
+    /**
+     * Fails the migration when an async-index statement matched but no {@code job_id} was
+     * capturable: with awaitAsyncIndexes enabled the wait must not be silently skipped, since a
+     * later step could run against an unbuilt index.
+     */
+    private static FlywayException missingJobId(String sql) {
+        return new FlywayException("Aurora DSQL async index build could not be awaited: "
+                + "awaitAsyncIndexes is enabled and this statement matched CREATE INDEX ASYNC, but "
+                + "no job_id was found in its result: " + sql);
+    }
+
+    /**
+     * Replaces every line ({@code -- ...}) and block ({@code /}{@code * ... *}{@code /}, nested)
+     * comment with a single space, so a comment cannot hide the {@code CREATE INDEX ASYNC} keywords
+     * whether it precedes them or sits between them. Flyway retains such comments in
+     * {@link Result#sql()}. Each comment becomes a space (not nothing) to keep keyword boundaries.
+     */
+    private static String stripComments(String sql) {
+        if (sql == null) {
+            return null;
+        }
+        StringBuilder out = new StringBuilder(sql.length());
+        int i = 0;
+        int n = sql.length();
+        while (i < n) {
+            if (sql.charAt(i) == '-' && i + 1 < n && sql.charAt(i + 1) == '-') {
+                int nl = sql.indexOf('\n', i + 2);
+                i = (nl < 0) ? n : nl + 1;
+                out.append(' ');
+            } else if (sql.charAt(i) == '/' && i + 1 < n && sql.charAt(i + 1) == '*') {
+                int depth = 1;
+                i += 2;
+                while (i < n && depth > 0) {
+                    if (sql.charAt(i) == '/' && i + 1 < n && sql.charAt(i + 1) == '*') {
+                        depth++;
+                        i += 2;
+                    } else if (sql.charAt(i) == '*' && i + 1 < n && sql.charAt(i + 1) == '/') {
+                        depth--;
+                        i += 2;
+                    } else {
+                        i++;
+                    }
+                }
+                out.append(' ');
+            } else {
+                out.append(sql.charAt(i++));
+            }
+        }
+        return out.toString().strip();
+    }
+
+    private void waitForJob(String jobId) {
+        boolean restoreAutoCommit = false;
+        RuntimeException primary = null;
+        try {
+            // sys.wait_for_job cannot run inside a transaction block. Flyway hands this executor a
+            // connection with an open transaction, so switch to autocommit (which commits the
+            // pending transaction) before the CALL, mirroring DSQLSchema.doClean(). Switching to
+            // autocommit is what commits the CREATE INDEX ASYNC that produced this job_id (it was
+            // still open in the migration's transaction), so the index exists before we wait on it.
+            // If this commit raises OCC, the DDL did not commit and DSQLExecutionTemplate replaying
+            // the migration is correct. The wait itself (a status read on sys.jobs) writes nothing,
+            // so it does not raise OCC — hence no local retry that would replay the committed DDL.
+            if (!connection.getAutoCommit()) {
+                connection.setAutoCommit(true);
+                restoreAutoCommit = true;
+            }
+            try (CallableStatement cs = connection.prepareCall("CALL sys.wait_for_job(?)")) {
+                cs.setString(1, jobId);
+                boolean hasResultSet = cs.execute();   // blocks server-side until the job finishes or times out
+                // sys.wait_for_job returns a single boolean: true = succeeded, false = the build
+                // did not succeed (it failed, or the wait timed out). A non-success does NOT raise
+                // (per the DSQL docs and verified live), so fail closed unless a true row is seen.
+                boolean succeeded = false;
+                if (hasResultSet) {
+                    try (ResultSet rs = cs.getResultSet()) {
+                        succeeded = rs.next() && rs.getBoolean(1);
+                    }
+                }
+                if (!succeeded) {
+                    throw new FlywayException(
+                            "Aurora DSQL async index build did not succeed (job_id=" + jobId
+                                    + "); it failed or the wait timed out — see sys.jobs for"
+                                    + " status and details");
+                }
+                LOG.fine("Waited for Aurora DSQL async index build, job_id=" + jobId);
+            }
+        } catch (SQLException e) {
+            primary = new FlywayException(
+                    "Aurora DSQL async index build failed or could not be awaited (job_id="
+                            + jobId + ")", e);
+        } catch (RuntimeException e) {
+            primary = e;
+        } finally {
+            if (restoreAutoCommit) {
+                try {
+                    connection.setAutoCommit(false);
+                } catch (SQLException e) {
+                    // A failed restore leaves the connection non-transactional for the rest of the
+                    // run, silently defeating rollback: never swallow it. Attach to any in-flight
+                    // error so that primary isn't masked; otherwise it becomes the failure.
+                    if (primary != null) {
+                        primary.addSuppressed(e);
+                    } else {
+                        primary = new FlywayException("Failed to restore autoCommit after Aurora "
+                                + "DSQL async index wait (job_id=" + jobId + ")", e);
+                    }
+                }
+            }
+        }
+        if (primary != null) {
+            throw primary;
+        }
+    }
+}

--- a/flyway-database-dsql/src/main/java/org/flywaydb/community/database/dsql/DSQLSqlScriptExecutorFactory.java
+++ b/flyway-database-dsql/src/main/java/org/flywaydb/community/database/dsql/DSQLSqlScriptExecutorFactory.java
@@ -1,0 +1,52 @@
+/*-
+ * ========================LICENSE_START=================================
+ * flyway-database-dsql
+ * ========================================================================
+ * Copyright (C) 2010 - 2026 Red Gate Software Ltd
+ * ========================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+package org.flywaydb.community.database.dsql;
+
+import org.flywaydb.core.internal.sqlscript.SqlScriptExecutor;
+import org.flywaydb.core.internal.sqlscript.SqlScriptExecutorFactory;
+
+import java.sql.Connection;
+
+/**
+ * Wraps the default {@link SqlScriptExecutorFactory} so each SQL-script executor can block on
+ * Aurora DSQL {@code CREATE INDEX ASYNC} builds when {@code flyway.dsql.awaitAsyncIndexes} is
+ * enabled (see {@link DSQLSqlScriptExecutor}). The factory always wraps; the blocking itself is
+ * opt-in and off by default.
+ *
+ * <p>Kept separate from the executor so it can be unit-tested with a fake delegate factory: the
+ * base factory closes over a {@code JdbcConnectionFactory} whose constructor opens a live
+ * connection, so the real one cannot be built with nulls.
+ */
+class DSQLSqlScriptExecutorFactory implements SqlScriptExecutorFactory {
+
+    private final SqlScriptExecutorFactory delegate;
+
+    DSQLSqlScriptExecutorFactory(SqlScriptExecutorFactory delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public SqlScriptExecutor createSqlScriptExecutor(Connection connection, boolean undo,
+                                                     boolean batch, boolean outputQueryResults) {
+        SqlScriptExecutor delegateExecutor =
+                delegate.createSqlScriptExecutor(connection, undo, batch, outputQueryResults);
+        return new DSQLSqlScriptExecutor(delegateExecutor, connection);
+    }
+}

--- a/flyway-database-dsql/src/main/java/org/flywaydb/community/database/dsql/DSQLTable.java
+++ b/flyway-database-dsql/src/main/java/org/flywaydb/community/database/dsql/DSQLTable.java
@@ -1,0 +1,46 @@
+/*-
+ * ========================LICENSE_START=================================
+ * flyway-database-dsql
+ * ========================================================================
+ * Copyright (C) 2010 - 2026 Red Gate Software Ltd
+ * ========================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+package org.flywaydb.community.database.dsql;
+
+import lombok.CustomLog;
+import org.flywaydb.core.internal.jdbc.JdbcTemplate;
+import org.flywaydb.database.postgresql.PostgreSQLSchema;
+import org.flywaydb.database.postgresql.PostgreSQLTable;
+
+import java.sql.SQLException;
+
+/**
+ * Aurora DSQL table implementation for Flyway.
+ *
+ * <p>Skips {@code FOR UPDATE} locking: DSQL requires an equality predicate on the key,
+ * which Flyway's default locking query does not provide.
+ */
+@CustomLog
+public class DSQLTable extends PostgreSQLTable {
+
+    public DSQLTable(JdbcTemplate jdbcTemplate, DSQLDatabase database, PostgreSQLSchema schema, String name) {
+        super(jdbcTemplate, database, schema, name);
+    }
+
+    @Override
+    protected void doLock() throws SQLException {
+        LOG.debug("Skipping FOR UPDATE lock on table " + getName() + " (not supported by Aurora DSQL)");
+    }
+}

--- a/flyway-database-dsql/src/main/java/org/flywaydb/community/database/dsql/DSQLTable.java
+++ b/flyway-database-dsql/src/main/java/org/flywaydb/community/database/dsql/DSQLTable.java
@@ -1,0 +1,47 @@
+/*-
+ * ========================LICENSE_START=================================
+ * flyway-database-dsql
+ * ========================================================================
+ * Copyright (C) 2010 - 2026 Red Gate Software Ltd
+ * ========================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+package org.flywaydb.community.database.dsql;
+
+import org.flywaydb.core.internal.jdbc.JdbcTemplate;
+import org.flywaydb.database.postgresql.PostgreSQLSchema;
+import org.flywaydb.database.postgresql.PostgreSQLTable;
+
+import java.sql.SQLException;
+import java.util.logging.Logger;
+
+/**
+ * Aurora DSQL table implementation for Flyway.
+ *
+ * <p>Skips {@code FOR UPDATE} locking: DSQL requires an equality predicate on the key,
+ * which Flyway's default locking query does not provide.
+ */
+public class DSQLTable extends PostgreSQLTable {
+
+    private static final Logger LOG = Logger.getLogger(DSQLTable.class.getName());
+
+    public DSQLTable(JdbcTemplate jdbcTemplate, DSQLDatabase database, PostgreSQLSchema schema, String name) {
+        super(jdbcTemplate, database, schema, name);
+    }
+
+    @Override
+    protected void doLock() throws SQLException {
+        LOG.fine("Skipping FOR UPDATE lock on table " + getName() + " (not supported by Aurora DSQL)");
+    }
+}

--- a/flyway-database-dsql/src/main/java/org/flywaydb/community/database/dsql/package-info.java
+++ b/flyway-database-dsql/src/main/java/org/flywaydb/community/database/dsql/package-info.java
@@ -1,0 +1,23 @@
+/*-
+ * ========================LICENSE_START=================================
+ * flyway-database-dsql
+ * ========================================================================
+ * Copyright (C) 2010 - 2026 Red Gate Software Ltd
+ * ========================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+/**
+ * Community-supported package. No compatibility guarantees provided.
+ */
+package org.flywaydb.community.database.dsql;

--- a/flyway-database-dsql/src/main/resources/META-INF/services/org.flywaydb.core.extensibility.Plugin
+++ b/flyway-database-dsql/src/main/resources/META-INF/services/org.flywaydb.core.extensibility.Plugin
@@ -1,0 +1,2 @@
+org.flywaydb.community.database.dsql.DSQLDatabaseType
+org.flywaydb.community.database.dsql.DSQLConfigurationExtension

--- a/flyway-database-dsql/src/main/resources/org/flywaydb/community/database/dsql/version.txt
+++ b/flyway-database-dsql/src/main/resources/org/flywaydb/community/database/dsql/version.txt
@@ -1,0 +1,1 @@
+${pom.version}

--- a/flyway-database-dsql/src/test/java/org/flywaydb/community/database/dsql/DSQLConfigurationExtensionTest.java
+++ b/flyway-database-dsql/src/test/java/org/flywaydb/community/database/dsql/DSQLConfigurationExtensionTest.java
@@ -1,0 +1,95 @@
+/*-
+ * ========================LICENSE_START=================================
+ * flyway-database-dsql
+ * ========================================================================
+ * Copyright (C) 2010 - 2026 Red Gate Software Ltd
+ * ========================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+package org.flywaydb.community.database.dsql;
+
+import org.flywaydb.core.extensibility.ConfigurationExtension;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DSQLConfigurationExtensionTest {
+
+    private final DSQLConfigurationExtension ext = new DSQLConfigurationExtension();
+
+    @Test
+    void namespaceIsDsql() {
+        assertThat(ext.getNamespace()).isEqualTo("dsql");
+    }
+
+    @Test
+    void occRetryIsOffByDefault() {
+        assertThat(ext.getOccMaxRetries()).isZero();
+        assertThat(ext.getOccMaxRetryDelaySeconds()).isEqualTo(5);
+    }
+
+    @Test
+    void awaitAsyncIndexesDefaultsToFalse() {
+        assertThat(ext.isAwaitAsyncIndexes()).isFalse();
+    }
+
+    @Test
+    void settersRoundTrip() {
+        ext.setOccMaxRetries(2);
+        ext.setOccMaxRetryDelaySeconds(10);
+        ext.setAwaitAsyncIndexes(true);
+        assertThat(ext.getOccMaxRetries()).isEqualTo(2);
+        assertThat(ext.getOccMaxRetryDelaySeconds()).isEqualTo(10);
+        assertThat(ext.isAwaitAsyncIndexes()).isTrue();
+    }
+
+    @Test
+    void envVarsMapToFlywayPrefixedKeys() {
+        assertThat(ext.getConfigurationParameterFromEnvironmentVariable("FLYWAY_DSQL_OCC_MAX_RETRIES"))
+                .isEqualTo("flyway.dsql.occMaxRetries");
+        assertThat(ext.getConfigurationParameterFromEnvironmentVariable("FLYWAY_DSQL_OCC_MAX_RETRY_DELAY_SECONDS"))
+                .isEqualTo("flyway.dsql.occMaxRetryDelaySeconds");
+        assertThat(ext.getConfigurationParameterFromEnvironmentVariable("FLYWAY_DSQL_AWAIT_ASYNC_INDEXES"))
+                .isEqualTo("flyway.dsql.awaitAsyncIndexes");
+        assertThat(ext.getConfigurationParameterFromEnvironmentVariable("FLYWAY_DSQL_UNKNOWN")).isNull();
+    }
+
+    // flyway-core (ConfigUtils) returns this value verbatim as the resolved property key, so it
+    // must be fully qualified with the "flyway." prefix — matching every core extension and the
+    // ClickHouse sibling ("flyway.<namespace>.<property>"). Without the prefix the env override
+    // never resolves (the bug this guards against).
+    @Test
+    void envKeysAreFullyQualifiedWithFlywayAndNamespace() {
+        String prefix = "flyway." + ext.getNamespace() + ".";
+        assertThat(ext.getConfigurationParameterFromEnvironmentVariable("FLYWAY_DSQL_OCC_MAX_RETRIES"))
+                .startsWith(prefix);
+        assertThat(ext.getConfigurationParameterFromEnvironmentVariable("FLYWAY_DSQL_OCC_MAX_RETRY_DELAY_SECONDS"))
+                .startsWith(prefix);
+        assertThat(ext.getConfigurationParameterFromEnvironmentVariable("FLYWAY_DSQL_AWAIT_ASYNC_INDEXES"))
+                .startsWith(prefix);
+    }
+
+    @Test
+    void copyPreservesValuesAndDoesNotThrow() {
+        ext.setOccMaxRetries(4);
+        ext.setOccMaxRetryDelaySeconds(15);
+        ext.setAwaitAsyncIndexes(true);
+        ConfigurationExtension copy = (ConfigurationExtension) ext.copy();
+        assertThat(copy).isInstanceOf(DSQLConfigurationExtension.class);
+        DSQLConfigurationExtension c = (DSQLConfigurationExtension) copy;
+        assertThat(c.getOccMaxRetries()).isEqualTo(4);
+        assertThat(c.getOccMaxRetryDelaySeconds()).isEqualTo(15);
+        assertThat(c.isAwaitAsyncIndexes()).isTrue();
+    }
+}

--- a/flyway-database-dsql/src/test/java/org/flywaydb/community/database/dsql/DSQLConnectionTest.java
+++ b/flyway-database-dsql/src/test/java/org/flywaydb/community/database/dsql/DSQLConnectionTest.java
@@ -1,0 +1,68 @@
+/*-
+ * ========================LICENSE_START=================================
+ * flyway-database-dsql
+ * ========================================================================
+ * Copyright (C) 2010 - 2026 Red Gate Software Ltd
+ * ========================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+package org.flywaydb.community.database.dsql;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Covers the schema-history reconcile statement. Only the statement is unit-testable:
+ * {@code PostgreSQLConnection}'s constructor queries {@code CURRENT_USER}, so a DSQLConnection
+ * instance cannot be built without a live cluster (exercised by {@link DSQLIntegrationTest}).
+ */
+class DSQLConnectionTest {
+
+    private static final String TABLE = "\"public\".\"flyway_schema_history\"";
+
+    @Test
+    void reconcileStatementDeletesOnlyLowerRankedSuccessfulRowsOfTheSameVersionAndType() {
+        assertThat(DSQLConnection.reconcileStatement(TABLE)).isEqualTo(
+                "DELETE FROM \"public\".\"flyway_schema_history\" h"
+                        + " WHERE h.\"version\" IS NOT NULL"
+                        + " AND h.\"success\" = TRUE"
+                        + " AND h.\"installed_rank\" < ("
+                        + "SELECT MAX(h2.\"installed_rank\") FROM \"public\".\"flyway_schema_history\" h2"
+                        + " WHERE h2.\"version\" = h.\"version\""
+                        + " AND h2.\"type\" = h.\"type\""
+                        + " AND h2.\"success\" = TRUE)");
+    }
+
+    /**
+     * Matching on version alone would delete the row a repair {@code DELETE} marker or an undo entry
+     * refers to, since Flyway appends those above it.
+     */
+    @Test
+    void reconcileStatementComparesTypeInBothOuterRowAndSubquery() {
+        assertThat(DSQLConnection.reconcileStatement(TABLE))
+                .contains("h2.\"type\" = h.\"type\"");
+    }
+
+    /**
+     * A migration that exhausts its retries records a failed row above the successful ones (DSQL has
+     * no DDL transactions, so failures are recorded). Restricting the subquery to successful rows
+     * keeps that row from making every successful row below it look superseded.
+     */
+    @Test
+    void reconcileStatementRestrictsBothSidesToSuccessfulRows() {
+        assertThat(DSQLConnection.reconcileStatement(TABLE))
+                .containsSubsequence("h.\"success\" = TRUE", "h2.\"success\" = TRUE");
+    }
+}

--- a/flyway-database-dsql/src/test/java/org/flywaydb/community/database/dsql/DSQLDatabaseTypeTest.java
+++ b/flyway-database-dsql/src/test/java/org/flywaydb/community/database/dsql/DSQLDatabaseTypeTest.java
@@ -1,0 +1,229 @@
+/*-
+ * ========================LICENSE_START=================================
+ * flyway-database-dsql
+ * ========================================================================
+ * Copyright (C) 2010 - 2026 Red Gate Software Ltd
+ * ========================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+package org.flywaydb.community.database.dsql;
+
+import org.flywaydb.core.api.configuration.FluentConfiguration;
+import org.flywaydb.core.internal.database.base.CommunityDatabaseType;
+import org.flywaydb.core.internal.exception.FlywaySqlException;
+import org.flywaydb.core.internal.jdbc.ExecutionTemplate;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Proxy;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class DSQLDatabaseTypeTest {
+
+    private final DSQLDatabaseType databaseType = new DSQLDatabaseType();
+
+    @Test
+    void nameIsAuroraDsql() {
+        assertThat(databaseType.getName()).isEqualTo("Aurora DSQL");
+    }
+
+    @Test
+    void isCommunityDatabaseType() {
+        assertThat(databaseType).isInstanceOf(CommunityDatabaseType.class);
+    }
+
+    @Test
+    void handlesAwsDsqlUrls() {
+        assertThat(databaseType.handlesJDBCUrl("jdbc:aws-dsql:postgresql://abc123.dsql.us-east-1.on.aws/postgres")).isTrue();
+        assertThat(databaseType.handlesJDBCUrl("jdbc:aws-dsql:postgresql://abc123.dsql.us-east-1.on.aws:5432/postgres")).isTrue();
+    }
+
+    @Test
+    void doesNotHandleUrlShapesTheConnectorRejects() {
+        // The connector accepts only jdbc:aws-dsql:postgresql:// (ConnUrlParser.isDsqlUrl), so
+        // claiming a broader prefix would select this type for a URL no driver can open.
+        assertThat(databaseType.handlesJDBCUrl("jdbc:aws-dsql://abc123.dsql.us-east-1.on.aws/postgres")).isFalse();
+        assertThat(databaseType.handlesJDBCUrl("jdbc:aws-dsql:abc123.dsql.us-east-1.on.aws/postgres")).isFalse();
+    }
+
+    @Test
+    void handlesTransformedPostgresqlUrlsWithDsqlEndpoint() {
+        assertThat(databaseType.handlesJDBCUrl("jdbc:postgresql://abc123.dsql.us-east-1.on.aws:5432/postgres")).isTrue();
+        assertThat(databaseType.handlesJDBCUrl("jdbc:postgresql://xyz789.dsql.eu-west-1.on.aws:5432/postgres")).isTrue();
+    }
+
+    @Test
+    void handlesPrivateLinkEndpoints() {
+        assertThat(databaseType.handlesJDBCUrl("jdbc:postgresql://abc123.dsql-fnh4.us-east-1.on.aws:5432/postgres")).isTrue();
+        assertThat(databaseType.handlesJDBCUrl("jdbc:aws-dsql:postgresql://abc123.dsql-fnh4.us-east-1.on.aws:5432/postgres")).isTrue();
+    }
+
+    @Test
+    void doesNotHandleNonDsqlUrls() {
+        assertThat(databaseType.handlesJDBCUrl("jdbc:postgresql://localhost:5432/mydb")).isFalse();
+        assertThat(databaseType.handlesJDBCUrl("jdbc:postgresql://mydb.abc123.us-east-1.rds.amazonaws.com:5432/mydb")).isFalse();
+        assertThat(databaseType.handlesJDBCUrl("jdbc:mysql://localhost:3306/mydb")).isFalse();
+        assertThat(databaseType.handlesJDBCUrl("jdbc:oracle:thin:@localhost:1521:xe")).isFalse();
+    }
+
+    @Test
+    void doesNotHandleDsqlPatternOutsideHost() {
+        // The DSQL pattern must match the host only: a ".dsql." in the database name or a query
+        // parameter must not hijack an ordinary PostgreSQL URL (priority 1 would win selection).
+        assertThat(databaseType.handlesJDBCUrl("jdbc:postgresql://localhost:5432/app.dsql.production")).isFalse();
+        assertThat(databaseType.handlesJDBCUrl("jdbc:postgresql://localhost:5432/app?ApplicationName=.dsql.")).isFalse();
+    }
+
+    @Test
+    void priorityIsHigherThanPostgres() {
+        assertThat(databaseType.getPriority()).isGreaterThan(0);
+    }
+
+    @Test
+    void driverClassIsDsqlConnectorForAwsDsqlUrls() {
+        assertThat(databaseType.getDriverClass("jdbc:aws-dsql:postgresql://abc123.dsql.us-east-1.on.aws/postgres", null))
+                .isEqualTo("software.amazon.dsql.jdbc.DSQLConnector");
+    }
+
+    @Test
+    void driverClassIsPostgresForTransformedUrls() {
+        assertThat(databaseType.getDriverClass("jdbc:postgresql://abc123.dsql.us-east-1.on.aws:5432/postgres", null))
+                .isEqualTo("org.postgresql.Driver");
+    }
+
+    @Test
+    void wrapsTransactionalTemplateWithOccRetryDecorator() {
+        // The commit-wrapping seam must return our OCC-retry decorator, otherwise a commit-time
+        // DSQL conflict is never retried. Base PostgreSQL just news up a TransactionalExecutionTemplate
+        // holding the connection (no I/O), so a null connection is fine for the type check.
+        ExecutionTemplate template = databaseType.createTransactionalExecutionTemplate(null, true);
+        assertThat(template).isInstanceOf(DSQLExecutionTemplate.class);
+    }
+
+    @Test
+    void configuredRetryCountReachesTheDecorator() {
+        // Joins the whole chain: configuration -> alterConnectionAsNeeded -> the transactional seam
+        // -> decorator. Asserted through behaviour (attempt count), so dropping the plumbing fails
+        // here instead of leaving the suite green.
+        FluentConfiguration config = new FluentConfiguration();
+        DSQLConfigurationExtension ext =
+                config.getPluginRegister().getPlugin(DSQLConfigurationExtension.class);
+        ext.setOccMaxRetries(2);
+        ext.setOccMaxRetryDelaySeconds(0); // floors at 100ms; keeps the backoff short
+
+        Connection connection = occConflictingConnection();
+        databaseType.alterConnectionAsNeeded(connection, config);
+        ExecutionTemplate template = databaseType.createTransactionalExecutionTemplate(connection, true);
+
+        AtomicInteger attempts = new AtomicInteger();
+        assertThatThrownBy(() -> template.execute(attempts::incrementAndGet))
+                .isInstanceOf(FlywaySqlException.class);
+        assertThat(attempts.get()).isEqualTo(3); // initial attempt + the 2 configured retries
+    }
+
+    @Test
+    void unregisteredConnectionUsesTheDefaultRetryCount() {
+        // Intercepted connections never reach alterConnectionAsNeeded, so they get the defaults;
+        // OCC retry is off by default, so such a connection must not retry.
+        ExecutionTemplate template =
+                databaseType.createTransactionalExecutionTemplate(occConflictingConnection(), true);
+
+        AtomicInteger attempts = new AtomicInteger();
+        assertThatThrownBy(() -> template.execute(attempts::incrementAndGet))
+                .isInstanceOf(FlywaySqlException.class);
+        assertThat(attempts.get()).isEqualTo(1);
+    }
+
+    /** Connection whose commit() reports a DSQL OCC conflict, where a real one also surfaces. */
+    private static Connection occConflictingConnection() {
+        return (Connection) Proxy.newProxyInstance(
+                DSQLDatabaseTypeTest.class.getClassLoader(), new Class<?>[]{Connection.class},
+                (proxy, method, args) -> {
+                    switch (method.getName()) {
+                        case "commit":
+                            throw new SQLException("write conflict", "OC000");
+                        case "getAutoCommit":
+                            return false;
+                        case "hashCode":
+                            return System.identityHashCode(proxy);
+                        case "equals":
+                            return proxy == args[0];
+                        case "toString":
+                            return "occConflictingConnection";
+                        default:
+                            return method.getReturnType() == boolean.class ? Boolean.FALSE : null;
+                    }
+                });
+    }
+
+    @Test
+    void wrapsSqlScriptExecutorFactoryForAsyncIndexWait() {
+        // The SQL-script executor seam must return our wrapper so CREATE INDEX ASYNC waits.
+        // Base PostgreSQL builds the delegate factory lazily (no I/O until an executor is made),
+        // so null collaborators are fine for the type check.
+        org.flywaydb.core.internal.sqlscript.SqlScriptExecutorFactory factory =
+                databaseType.createSqlScriptExecutorFactory(null, null, null);
+        assertThat(factory).isInstanceOf(DSQLSqlScriptExecutorFactory.class);
+    }
+
+    @Test
+    void maxRetryDelayConvertsSecondsToMillis() {
+        // Guards the seconds->millis conversion: dropping the *1000 would make backoff 1000x too short.
+        assertThat(DSQLDatabaseType.maxRetryDelayMillis(30)).isEqualTo(30_000L);
+    }
+
+    @Test
+    void maxRetryDelayFloorsAtMinimum() {
+        // A zero or negative configured cap must not disable backoff; it floors at 100ms.
+        assertThat(DSQLDatabaseType.maxRetryDelayMillis(0)).isEqualTo(100L);
+        assertThat(DSQLDatabaseType.maxRetryDelayMillis(-5)).isEqualTo(100L);
+    }
+
+    @Test
+    void resolveKnobsFallsBackToDefaultsWhenConfigNull() {
+        assertThat(DSQLDatabaseType.resolveOccRetryKnobs(null)).containsExactly(0, 5);
+    }
+
+    @Test
+    void resolveKnobsReadsConfiguredExtensionValues() {
+        // Drives the real resolution path: FluentConfiguration auto-registers the extension via
+        // ServiceLoader. That the resolved values reach the decorator is covered separately by
+        // configuredRetryCountReachesTheDecorator.
+        FluentConfiguration config = new FluentConfiguration();
+        DSQLConfigurationExtension ext =
+                config.getPluginRegister().getPlugin(DSQLConfigurationExtension.class);
+        ext.setOccMaxRetries(3);
+        ext.setOccMaxRetryDelaySeconds(10);
+        assertThat(DSQLDatabaseType.resolveOccRetryKnobs(config)).containsExactly(3, 10);
+    }
+
+    @Test
+    void resolveKnobsClampsNegativeRetriesToZero() {
+        FluentConfiguration config = new FluentConfiguration();
+        config.getPluginRegister().getPlugin(DSQLConfigurationExtension.class).setOccMaxRetries(-1);
+        assertThat(DSQLDatabaseType.resolveOccRetryKnobs(config)[0]).isZero();
+    }
+
+    @Test
+    void resolveKnobsClampsExcessiveRetriesToConnectorMax() {
+        // The clamp keeps an oversized config value from looping for hours.
+        FluentConfiguration config = new FluentConfiguration();
+        config.getPluginRegister().getPlugin(DSQLConfigurationExtension.class).setOccMaxRetries(500);
+        assertThat(DSQLDatabaseType.resolveOccRetryKnobs(config)[0]).isEqualTo(100);
+    }
+}

--- a/flyway-database-dsql/src/test/java/org/flywaydb/community/database/dsql/DSQLDatabaseTypeTest.java
+++ b/flyway-database-dsql/src/test/java/org/flywaydb/community/database/dsql/DSQLDatabaseTypeTest.java
@@ -1,0 +1,159 @@
+/*-
+ * ========================LICENSE_START=================================
+ * flyway-database-dsql
+ * ========================================================================
+ * Copyright (C) 2010 - 2026 Red Gate Software Ltd
+ * ========================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+package org.flywaydb.community.database.dsql;
+
+import org.flywaydb.core.api.configuration.FluentConfiguration;
+import org.flywaydb.core.internal.database.base.CommunityDatabaseType;
+import org.flywaydb.core.internal.jdbc.ExecutionTemplate;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DSQLDatabaseTypeTest {
+
+    private final DSQLDatabaseType databaseType = new DSQLDatabaseType();
+
+    @Test
+    void nameIsAuroraDsql() {
+        assertThat(databaseType.getName()).isEqualTo("Aurora DSQL");
+    }
+
+    @Test
+    void isCommunityDatabaseType() {
+        assertThat(databaseType).isInstanceOf(CommunityDatabaseType.class);
+    }
+
+    @Test
+    void handlesAwsDsqlUrls() {
+        assertThat(databaseType.handlesJDBCUrl("jdbc:aws-dsql:postgresql://abc123.dsql.us-east-1.on.aws/postgres")).isTrue();
+        assertThat(databaseType.handlesJDBCUrl("jdbc:aws-dsql:postgresql://abc123.dsql.us-east-1.on.aws:5432/postgres")).isTrue();
+        assertThat(databaseType.handlesJDBCUrl("jdbc:aws-dsql://abc123.dsql.us-east-1.on.aws/postgres")).isTrue();
+    }
+
+    @Test
+    void handlesTransformedPostgresqlUrlsWithDsqlEndpoint() {
+        assertThat(databaseType.handlesJDBCUrl("jdbc:postgresql://abc123.dsql.us-east-1.on.aws:5432/postgres")).isTrue();
+        assertThat(databaseType.handlesJDBCUrl("jdbc:postgresql://xyz789.dsql.eu-west-1.on.aws:5432/postgres")).isTrue();
+    }
+
+    @Test
+    void handlesPrivateLinkEndpoints() {
+        assertThat(databaseType.handlesJDBCUrl("jdbc:postgresql://abc123.dsql-fnh4.us-east-1.on.aws:5432/postgres")).isTrue();
+        assertThat(databaseType.handlesJDBCUrl("jdbc:aws-dsql:postgresql://abc123.dsql-fnh4.us-east-1.on.aws:5432/postgres")).isTrue();
+    }
+
+    @Test
+    void doesNotHandleNonDsqlUrls() {
+        assertThat(databaseType.handlesJDBCUrl("jdbc:postgresql://localhost:5432/mydb")).isFalse();
+        assertThat(databaseType.handlesJDBCUrl("jdbc:postgresql://mydb.abc123.us-east-1.rds.amazonaws.com:5432/mydb")).isFalse();
+        assertThat(databaseType.handlesJDBCUrl("jdbc:mysql://localhost:3306/mydb")).isFalse();
+        assertThat(databaseType.handlesJDBCUrl("jdbc:oracle:thin:@localhost:1521:xe")).isFalse();
+    }
+
+    @Test
+    void doesNotHandleDsqlPatternOutsideHost() {
+        // The DSQL pattern must match the host only: a ".dsql." in the database name or a query
+        // parameter must not hijack an ordinary PostgreSQL URL (priority 1 would win selection).
+        assertThat(databaseType.handlesJDBCUrl("jdbc:postgresql://localhost:5432/app.dsql.production")).isFalse();
+        assertThat(databaseType.handlesJDBCUrl("jdbc:postgresql://localhost:5432/app?ApplicationName=.dsql.")).isFalse();
+    }
+
+    @Test
+    void priorityIsHigherThanPostgres() {
+        assertThat(databaseType.getPriority()).isGreaterThan(0);
+    }
+
+    @Test
+    void driverClassIsDsqlConnectorForAwsDsqlUrls() {
+        assertThat(databaseType.getDriverClass("jdbc:aws-dsql:postgresql://abc123.dsql.us-east-1.on.aws/postgres", null))
+                .isEqualTo("software.amazon.dsql.jdbc.DSQLConnector");
+    }
+
+    @Test
+    void driverClassIsPostgresForTransformedUrls() {
+        assertThat(databaseType.getDriverClass("jdbc:postgresql://abc123.dsql.us-east-1.on.aws:5432/postgres", null))
+                .isEqualTo("org.postgresql.Driver");
+    }
+
+    @Test
+    void wrapsTransactionalTemplateWithOccRetryDecorator() {
+        // The commit-wrapping seam must return our OCC-retry decorator, otherwise a commit-time
+        // DSQL conflict is never retried. Base PostgreSQL just news up a TransactionalExecutionTemplate
+        // holding the connection (no I/O), so a null connection is fine for the type check.
+        ExecutionTemplate template = databaseType.createTransactionalExecutionTemplate(null, true);
+        assertThat(template).isInstanceOf(DSQLExecutionTemplate.class);
+    }
+
+    @Test
+    void wrapsSqlScriptExecutorFactoryForAsyncIndexWait() {
+        // The SQL-script executor seam must return our wrapper so CREATE INDEX ASYNC waits.
+        // Base PostgreSQL builds the delegate factory lazily (no I/O until an executor is made),
+        // so null collaborators are fine for the type check.
+        org.flywaydb.core.internal.sqlscript.SqlScriptExecutorFactory factory =
+                databaseType.createSqlScriptExecutorFactory(null, null, null);
+        assertThat(factory).isInstanceOf(DSQLSqlScriptExecutorFactory.class);
+    }
+
+    @Test
+    void maxRetryDelayConvertsSecondsToMillis() {
+        // Guards the seconds->millis conversion: dropping the *1000 would make backoff 1000x too short.
+        assertThat(DSQLDatabaseType.maxRetryDelayMillis(30)).isEqualTo(30_000L);
+    }
+
+    @Test
+    void maxRetryDelayFloorsAtMinimum() {
+        // A zero or negative configured cap must not disable backoff; it floors at 100ms.
+        assertThat(DSQLDatabaseType.maxRetryDelayMillis(0)).isEqualTo(100L);
+        assertThat(DSQLDatabaseType.maxRetryDelayMillis(-5)).isEqualTo(100L);
+    }
+
+    @Test
+    void resolveKnobsFallsBackToDefaultsWhenConfigNull() {
+        assertThat(DSQLDatabaseType.resolveOccRetryKnobs(null)).containsExactly(0, 5);
+    }
+
+    @Test
+    void resolveKnobsReadsConfiguredExtensionValues() {
+        // Drives the real resolution path: FluentConfiguration auto-registers the extension via
+        // ServiceLoader, so this proves configured values actually reach createTransactionalExecutionTemplate.
+        FluentConfiguration config = new FluentConfiguration();
+        DSQLConfigurationExtension ext =
+                config.getPluginRegister().getPlugin(DSQLConfigurationExtension.class);
+        ext.setOccMaxRetries(3);
+        ext.setOccMaxRetryDelaySeconds(10);
+        assertThat(DSQLDatabaseType.resolveOccRetryKnobs(config)).containsExactly(3, 10);
+    }
+
+    @Test
+    void resolveKnobsClampsNegativeRetriesToZero() {
+        FluentConfiguration config = new FluentConfiguration();
+        config.getPluginRegister().getPlugin(DSQLConfigurationExtension.class).setOccMaxRetries(-1);
+        assertThat(DSQLDatabaseType.resolveOccRetryKnobs(config)[0]).isZero();
+    }
+
+    @Test
+    void resolveKnobsClampsExcessiveRetriesToConnectorMax() {
+        // OCCRetryConfig.build() rejects maxRetries > 100; the clamp keeps an oversized config value
+        // from failing the migration when building the retry config.
+        FluentConfiguration config = new FluentConfiguration();
+        config.getPluginRegister().getPlugin(DSQLConfigurationExtension.class).setOccMaxRetries(500);
+        assertThat(DSQLDatabaseType.resolveOccRetryKnobs(config)[0]).isEqualTo(100);
+    }
+}

--- a/flyway-database-dsql/src/test/java/org/flywaydb/community/database/dsql/DSQLExecutionTemplateTest.java
+++ b/flyway-database-dsql/src/test/java/org/flywaydb/community/database/dsql/DSQLExecutionTemplateTest.java
@@ -1,0 +1,136 @@
+/*-
+ * ========================LICENSE_START=================================
+ * flyway-database-dsql
+ * ========================================================================
+ * Copyright (C) 2010 - 2026 Red Gate Software Ltd
+ * ========================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+package org.flywaydb.community.database.dsql;
+
+import org.flywaydb.core.api.FlywayException;
+import org.flywaydb.core.internal.exception.FlywaySqlException;
+import org.flywaydb.core.internal.jdbc.ExecutionTemplate;
+import org.junit.jupiter.api.Test;
+
+import java.sql.SQLException;
+import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class DSQLExecutionTemplateTest {
+
+    // Fake delegate template that simulates flyway-core's TransactionalExecutionTemplate:
+    // it invokes the callback, then "commits" — surfacing pre-scripted commit outcomes as the
+    // FlywaySqlException that a real commit-time OCC conflict throws (thrown at the transaction
+    // boundary, NOT inside a single statement).
+    private static class FakeTemplate implements ExecutionTemplate {
+        final AtomicInteger executes = new AtomicInteger();
+        private final RuntimeException[] commitOutcomes; // null entry => commit succeeds
+
+        FakeTemplate(RuntimeException... commitOutcomes) {
+            this.commitOutcomes = commitOutcomes;
+        }
+
+        @Override
+        public <T> T execute(Callable<T> callback) {
+            int i = executes.getAndIncrement();
+            try {
+                T result = callback.call();
+                RuntimeException outcome = i < commitOutcomes.length ? commitOutcomes[i] : null;
+                if (outcome != null) {
+                    throw outcome; // simulate connection.commit() failing
+                }
+                return result;
+            } catch (RuntimeException e) {
+                throw e;
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    private static FlywaySqlException occCommitFailure() {
+        // Mirrors TransactionalExecutionTemplate wrapping a commit SQLException.
+        return new FlywaySqlException("Unable to commit transaction",
+                new SQLException("catalog conflict", "OC001"));
+    }
+
+    private static FlywaySqlException nonOccCommitFailure() {
+        return new FlywaySqlException("Unable to commit transaction",
+                new SQLException("syntax error", "42601"));
+    }
+
+    // fast backoff: a 1ms delay cap keeps sleeps negligible for tests
+    private DSQLExecutionTemplate template(FakeTemplate delegate, int maxRetries) {
+        return new DSQLExecutionTemplate(delegate, maxRetries, 1L);
+    }
+
+    @Test
+    void retriesCommitTimeOccThenSucceeds() {
+        FakeTemplate delegate = new FakeTemplate(occCommitFailure(), null);
+        String result = template(delegate, 6).execute(() -> "ok");
+        assertThat(result).isEqualTo("ok");
+        assertThat(delegate.executes.get()).isEqualTo(2); // initial + 1 retry
+    }
+
+    @Test
+    void doesNotRetryNonOccCommitFailure() {
+        FakeTemplate delegate = new FakeTemplate(nonOccCommitFailure(), null);
+        assertThatThrownBy(() -> template(delegate, 6).execute(() -> "ok"))
+                .isInstanceOf(FlywaySqlException.class);
+        assertThat(delegate.executes.get()).isEqualTo(1);
+    }
+
+    @Test
+    void exhaustsRetriesThenRethrows() {
+        FakeTemplate delegate = new FakeTemplate(
+                occCommitFailure(), occCommitFailure(), occCommitFailure(), occCommitFailure());
+        assertThatThrownBy(() -> template(delegate, 2).execute(() -> "ok"))
+                .isInstanceOf(FlywaySqlException.class);
+        assertThat(delegate.executes.get()).isEqualTo(3); // initial + 2 retries
+    }
+
+    @Test
+    void zeroRetriesExecutesOnce() {
+        FakeTemplate delegate = new FakeTemplate(occCommitFailure(), null);
+        assertThatThrownBy(() -> template(delegate, 0).execute(() -> "ok"))
+                .isInstanceOf(FlywaySqlException.class);
+        assertThat(delegate.executes.get()).isEqualTo(1);
+    }
+
+    @Test
+    void passesThroughSuccessWithoutRetry() {
+        FakeTemplate delegate = new FakeTemplate();
+        String result = template(delegate, 6).execute(() -> "done");
+        assertThat(result).isEqualTo("done");
+        assertThat(delegate.executes.get()).isEqualTo(1);
+    }
+
+    @Test
+    void interruptDuringBackoffThrowsFlywayException() {
+        FakeTemplate delegate = new FakeTemplate(occCommitFailure(), null);
+        Thread.currentThread().interrupt();
+        try {
+            assertThatThrownBy(() -> template(delegate, 6).execute(() -> "ok"))
+                    .isInstanceOf(FlywayException.class)
+                    .hasMessageContaining("interrupted");
+        } finally {
+            // clear the interrupt flag so it doesn't leak into other tests
+            Thread.interrupted();
+        }
+    }
+}

--- a/flyway-database-dsql/src/test/java/org/flywaydb/community/database/dsql/DSQLExecutionTemplateTest.java
+++ b/flyway-database-dsql/src/test/java/org/flywaydb/community/database/dsql/DSQLExecutionTemplateTest.java
@@ -1,0 +1,142 @@
+/*-
+ * ========================LICENSE_START=================================
+ * flyway-database-dsql
+ * ========================================================================
+ * Copyright (C) 2010 - 2026 Red Gate Software Ltd
+ * ========================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+package org.flywaydb.community.database.dsql;
+
+import org.flywaydb.core.api.FlywayException;
+import org.flywaydb.core.internal.exception.FlywaySqlException;
+import org.flywaydb.core.internal.jdbc.ExecutionTemplate;
+import org.junit.jupiter.api.Test;
+import software.amazon.dsql.jdbc.OCCRetryConfig;
+
+import java.sql.SQLException;
+import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class DSQLExecutionTemplateTest {
+
+    // Fake delegate template that simulates flyway-core's TransactionalExecutionTemplate:
+    // it invokes the callback, then "commits" — surfacing pre-scripted commit outcomes as the
+    // FlywaySqlException that a real commit-time OCC conflict throws (thrown at the transaction
+    // boundary, NOT inside a single statement).
+    private static class FakeTemplate implements ExecutionTemplate {
+        final AtomicInteger executes = new AtomicInteger();
+        private final RuntimeException[] commitOutcomes; // null entry => commit succeeds
+
+        FakeTemplate(RuntimeException... commitOutcomes) {
+            this.commitOutcomes = commitOutcomes;
+        }
+
+        @Override
+        public <T> T execute(Callable<T> callback) {
+            int i = executes.getAndIncrement();
+            try {
+                T result = callback.call();
+                RuntimeException outcome = i < commitOutcomes.length ? commitOutcomes[i] : null;
+                if (outcome != null) {
+                    throw outcome; // simulate connection.commit() failing
+                }
+                return result;
+            } catch (RuntimeException e) {
+                throw e;
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    private static FlywaySqlException occCommitFailure() {
+        // Mirrors TransactionalExecutionTemplate wrapping a commit SQLException.
+        return new FlywaySqlException("Unable to commit transaction",
+                new SQLException("catalog conflict", "OC001"));
+    }
+
+    private static FlywaySqlException nonOccCommitFailure() {
+        return new FlywaySqlException("Unable to commit transaction",
+                new SQLException("syntax error", "42601"));
+    }
+
+    // fast backoff: 1ms base/max delay keeps sleeps negligible for tests
+    private DSQLExecutionTemplate template(FakeTemplate delegate, int maxRetries) {
+        OCCRetryConfig config = OCCRetryConfig.builder()
+                .maxRetries(maxRetries)
+                .baseDelayMs(1L)
+                .maxDelayMs(1L)
+                .build();
+        return new DSQLExecutionTemplate(delegate, config);
+    }
+
+    @Test
+    void retriesCommitTimeOccThenSucceeds() {
+        FakeTemplate delegate = new FakeTemplate(occCommitFailure(), null);
+        String result = template(delegate, 6).execute(() -> "ok");
+        assertThat(result).isEqualTo("ok");
+        assertThat(delegate.executes.get()).isEqualTo(2); // initial + 1 retry
+    }
+
+    @Test
+    void doesNotRetryNonOccCommitFailure() {
+        FakeTemplate delegate = new FakeTemplate(nonOccCommitFailure(), null);
+        assertThatThrownBy(() -> template(delegate, 6).execute(() -> "ok"))
+                .isInstanceOf(FlywaySqlException.class);
+        assertThat(delegate.executes.get()).isEqualTo(1);
+    }
+
+    @Test
+    void exhaustsRetriesThenRethrows() {
+        FakeTemplate delegate = new FakeTemplate(
+                occCommitFailure(), occCommitFailure(), occCommitFailure(), occCommitFailure());
+        assertThatThrownBy(() -> template(delegate, 2).execute(() -> "ok"))
+                .isInstanceOf(FlywaySqlException.class);
+        assertThat(delegate.executes.get()).isEqualTo(3); // initial + 2 retries
+    }
+
+    @Test
+    void zeroRetriesExecutesOnce() {
+        FakeTemplate delegate = new FakeTemplate(occCommitFailure(), null);
+        assertThatThrownBy(() -> template(delegate, 0).execute(() -> "ok"))
+                .isInstanceOf(FlywaySqlException.class);
+        assertThat(delegate.executes.get()).isEqualTo(1);
+    }
+
+    @Test
+    void passesThroughSuccessWithoutRetry() {
+        FakeTemplate delegate = new FakeTemplate();
+        String result = template(delegate, 6).execute(() -> "done");
+        assertThat(result).isEqualTo("done");
+        assertThat(delegate.executes.get()).isEqualTo(1);
+    }
+
+    @Test
+    void interruptDuringBackoffThrowsFlywayException() {
+        FakeTemplate delegate = new FakeTemplate(occCommitFailure(), null);
+        Thread.currentThread().interrupt();
+        try {
+            assertThatThrownBy(() -> template(delegate, 6).execute(() -> "ok"))
+                    .isInstanceOf(FlywayException.class)
+                    .hasMessageContaining("interrupted");
+        } finally {
+            // clear the interrupt flag so it doesn't leak into other tests
+            Thread.interrupted();
+        }
+    }
+}

--- a/flyway-database-dsql/src/test/java/org/flywaydb/community/database/dsql/DSQLIntegrationTest.java
+++ b/flyway-database-dsql/src/test/java/org/flywaydb/community/database/dsql/DSQLIntegrationTest.java
@@ -1,0 +1,365 @@
+/*-
+ * ========================LICENSE_START=================================
+ * flyway-database-dsql
+ * ========================================================================
+ * Copyright (C) 2010 - 2026 Red Gate Software Ltd
+ * ========================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+package org.flywaydb.community.database.dsql;
+
+import org.flywaydb.core.Flyway;
+import org.flywaydb.core.api.MigrationVersion;
+import org.flywaydb.core.api.configuration.FluentConfiguration;
+import org.flywaydb.core.api.migration.Context;
+import org.flywaydb.core.api.migration.JavaMigration;
+import org.flywaydb.core.api.output.MigrateResult;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * End-to-end live-cluster test for the Aurora DSQL OCC retry.
+ *
+ * <p>Aurora DSQL is a managed AWS service with no local, embedded, or Testcontainers equivalent,
+ * so this test cannot run in CI. It is gated on the {@code DSQL_CLUSTER_ENDPOINT} environment
+ * variable and is silently skipped whenever that variable is absent (i.e. always, in CI). The
+ * deterministic {@link DSQLExecutionTemplateTest} carries the retry regression coverage that does
+ * run in CI; this test is the on-demand proof against a real cluster.
+ *
+ * <p>It drives the full Flyway stack — {@link Flyway#migrate()} against a live cluster through the
+ * {@code jdbc:aws-dsql:} connector — and induces a <em>real</em> commit-time OCC conflict from
+ * inside a Java migration: on its first attempt the migration writes row 1 on Flyway's own
+ * connection, then a second connection commits a conflicting write to the same row before the
+ * migration returns. Flyway's {@code commit()} therefore loses the OCC race and surfaces a genuine
+ * {@code OC000}/{@code OC001}/{@code 40001} SQLSTATE, which the module's {@link DSQLExecutionTemplate}
+ * (installed via {@link DSQLDatabaseType}) retries. The retry re-runs the migration with no
+ * conflict and commits, so {@code migrate()} succeeds and the retry's value is what persists.
+ *
+ * <p>Run locally with AWS credentials on the default provider chain and:
+ * <pre>{@code
+ * export DSQL_CLUSTER_ENDPOINT=<cluster-id>.dsql.<region>.on.aws
+ * ./mvnw -pl flyway-database-dsql test -Dtest=DSQLIntegrationTest
+ * }</pre>
+ * All work stays in an isolated {@code flyway_dsql_test} schema; it never touches {@code public}.
+ */
+@EnabledIfEnvironmentVariable(named = "DSQL_CLUSTER_ENDPOINT", matches = ".+")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class DSQLIntegrationTest {
+
+    private static final String SCHEMA = "flyway_dsql_test";
+    private static final String TABLE = SCHEMA + ".occ_e2e";
+    private static final String HISTORY = SCHEMA + ".flyway_schema_history";
+
+    private String jdbcUrl() {
+        return "jdbc:aws-dsql:postgresql://" + System.getenv("DSQL_CLUSTER_ENDPOINT") + "/postgres";
+    }
+
+    private String user() {
+        return System.getenv().getOrDefault("DSQL_CLUSTER_USER", "admin");
+    }
+
+    private Connection open() throws Exception {
+        Properties props = new Properties();
+        // The connector generates the IAM token from the default AWS credential chain and parses
+        // the region from the endpoint hostname; no password is supplied.
+        props.setProperty("user", user());
+        return DriverManager.getConnection(jdbcUrl(), props);
+    }
+
+    // Schema and table DDL runs once per class, not per test: DSQL's catalog is distributed and
+    // reactively discovered, so repeating CREATE/DROP TABLE races other work and itself raises
+    // catalog OC001 conflicts. The schema is pre-created because Flyway bootstraps its history
+    // table on a separate connection that cannot yet see a just-created schema.
+    @BeforeAll
+    void createSchemaAndTable() throws Exception {
+        try (Connection c = open(); Statement s = c.createStatement()) {
+            c.setAutoCommit(true);
+            s.execute("CREATE SCHEMA IF NOT EXISTS " + SCHEMA);
+            s.execute("DROP TABLE IF EXISTS " + HISTORY);
+            s.execute("DROP TABLE IF EXISTS " + TABLE);
+            s.execute("CREATE TABLE " + TABLE + " (id int PRIMARY KEY, val int)");
+        }
+    }
+
+    @AfterAll
+    void dropTable() throws Exception {
+        try (Connection c = open(); Statement s = c.createStatement()) {
+            c.setAutoCommit(true);
+            s.execute("DROP TABLE IF EXISTS " + TABLE);
+        }
+    }
+
+    @BeforeEach
+    void resetState() throws Exception {
+        // DML only: repeating DDL here races DSQL's distributed catalog and raises OCC conflicts,
+        // so all table/history DDL lives in the once-per-class setup above.
+        try (Connection c = open(); Statement s = c.createStatement()) {
+            c.setAutoCommit(true);
+            s.execute("DELETE FROM " + TABLE);
+            s.execute("INSERT INTO " + TABLE + " (id, val) VALUES (1, 0)");
+            // Each test applies its own version-1 migration with a distinct checksum against the
+            // shared schema, so clear any prior test's history rows; otherwise Flyway's validation
+            // fails the next migrate with a checksum mismatch. DML only — dropping the history
+            // table would repeat DDL on the same object and race the catalog (see @BeforeAll).
+            if (historyExists(s)) {
+                s.execute("DELETE FROM " + HISTORY);
+            }
+        }
+    }
+
+    private boolean historyExists(Statement s) throws Exception {
+        try (ResultSet rs = s.executeQuery(
+                "SELECT 1 FROM information_schema.tables WHERE table_schema = '" + SCHEMA
+                        + "' AND table_name = 'flyway_schema_history'")) {
+            return rs.next();
+        }
+    }
+
+    @Test
+    void migrateRetriesCommitTimeOccConflictAndSucceeds() {
+        AtomicInteger attempts = new AtomicInteger();
+
+        FluentConfiguration config = Flyway.configure()
+                .dataSource(jdbcUrl(), user(), null)
+                .schemas(SCHEMA)
+                // The schema already holds the fixture table (occ_e2e), so baseline the empty
+                // history rather than requiring an empty schema. Baseline at v0 so it stays
+                // distinct from the v1 migration under test.
+                .baselineOnMigrate(true)
+                .baselineVersion("0")
+                .javaMigrations(new ConflictOnFirstAttempt(attempts));
+        // OCC retry is off by default; opt in so the commit-time conflict is retried.
+        config.getPluginRegister().getPlugin(DSQLConfigurationExtension.class)
+                .setOccMaxRetries(3);
+        Flyway flyway = config.load();
+
+        MigrateResult result = flyway.migrate();
+
+        assertThat(result.success).isTrue();
+        assertThat(result.migrationsExecuted).isEqualTo(1);
+        // The migration ran twice: the first commit lost the OCC race and the module retried it.
+        assertThat(attempts.get()).isEqualTo(2);
+        // The retry's write (102) is what persisted, overwriting the conflicting 999.
+        assertThat(committedVal()).isEqualTo(102);
+        assertThat(appliedVersions()).contains("1");
+        // The retry's history insert commits on the auto-commit main connection before the failed
+        // commit, orphaning the first attempt's row. DSQLConnection reconciles it, so exactly one
+        // successful history row must remain for the version (not two).
+        assertThat(successfulRowCount("1")).isEqualTo(1);
+    }
+
+    @Test
+    void migrateWaitsForAsyncIndexBuild() throws Exception {
+        // Populate a table large enough that CREATE INDEX ASYNC lags the statement, then run a
+        // SQL migration that creates the index ASYNC. If the wait fires, the index is fully built
+        // (not 'building') the moment migrate() returns. This check is timing-dependent — a build
+        // fast enough to finish before the status read would pass even without the wait; the
+        // deterministic proof that the wait blocks and inspects the result is
+        // migrateFailsWhenAsyncIndexBuildFails, which can only fail the migration if it does.
+        String idxTable = SCHEMA + ".async_idx_e2e";
+        int rows = 60000;
+        int batch = 2500;   // DSQL caps mutations at 3,000 rows per transaction; stay under it.
+        try (Connection c = open(); Statement s = c.createStatement()) {
+            c.setAutoCommit(true);
+            s.execute("DROP TABLE IF EXISTS " + idxTable);
+            s.execute("CREATE TABLE " + idxTable + " (id int PRIMARY KEY, val int)");
+            for (int start = 1; start <= rows; start += batch) {
+                int end = Math.min(start + batch - 1, rows);
+                s.execute("INSERT INTO " + idxTable
+                        + " SELECT g, g FROM generate_series(" + start + ", " + end + ") g");
+            }
+        }
+
+        try {
+            java.nio.file.Path dir = java.nio.file.Files.createTempDirectory("dsql-async-idx");
+            // Leading comment on the statement exercises comment-stripping: the wait must still
+            // recognize CREATE INDEX ASYNC and block on the build (Flyway keeps the comment in
+            // Result.sql()).
+            java.nio.file.Files.writeString(dir.resolve("V1__create_async_index.sql"),
+                    "-- build the value index\n"
+                            + "CREATE INDEX ASYNC async_idx_e2e_val ON " + idxTable + " (val);\n");
+
+            FluentConfiguration config = Flyway.configure()
+                    .dataSource(jdbcUrl(), user(), null)
+                    .schemas(SCHEMA)
+                    .baselineOnMigrate(true)
+                    .baselineVersion("0")
+                    .locations("filesystem:" + dir.toAbsolutePath());
+            // The wait is opt-in; enable it so the migration blocks until the build completes.
+            config.getPluginRegister().getPlugin(DSQLConfigurationExtension.class)
+                    .setAwaitAsyncIndexes(true);
+            Flyway flyway = config.load();
+
+            MigrateResult result = flyway.migrate();
+            assertThat(result.success).isTrue();
+            assertThat(result.migrationsExecuted).isEqualTo(1);
+
+            // The index must be present and no longer building the instant migrate() returned.
+            // object_name is schema-qualified (e.g. flyway_dsql_test.async_idx_e2e_val), so match
+            // the qualified name built from SCHEMA rather than the bare index name.
+            try (Connection c = open(); Statement s = c.createStatement();
+                 ResultSet rs = s.executeQuery(
+                         "SELECT status FROM sys.jobs WHERE object_name = '"
+                                 + SCHEMA + ".async_idx_e2e_val'")) {
+                // sys.jobs purges completed rows after ~30 min; either it is gone (completed+purged)
+                // or, if still listed, it must be 'completed' — never 'submitted'/'building'.
+                if (rs.next()) {
+                    assertThat(rs.getString(1)).isEqualTo("completed");
+                }
+            }
+        } finally {
+            try (Connection c = open(); Statement s = c.createStatement()) {
+                c.setAutoCommit(true);
+                s.execute("DROP TABLE IF EXISTS " + idxTable);
+            }
+        }
+    }
+
+    @Test
+    void migrateFailsWhenAsyncIndexBuildFails() throws Exception {
+        // Deterministic failure: a UNIQUE index over duplicate values cannot build, so
+        // sys.wait_for_job returns false and the wait must fail the migration. Unlike the success
+        // test this does not depend on build timing — the build is guaranteed to fail.
+        String idxTable = SCHEMA + ".async_idx_fail";
+        try (Connection c = open(); Statement s = c.createStatement()) {
+            c.setAutoCommit(true);
+            s.execute("DROP TABLE IF EXISTS " + idxTable);
+            s.execute("CREATE TABLE " + idxTable + " (id int PRIMARY KEY, val int)");
+            // Two rows sharing val = 1 make a UNIQUE index on val impossible.
+            s.execute("INSERT INTO " + idxTable + " (id, val) VALUES (1, 1), (2, 1)");
+        }
+
+        try {
+            java.nio.file.Path dir = java.nio.file.Files.createTempDirectory("dsql-async-idx-fail");
+            java.nio.file.Files.writeString(dir.resolve("V1__create_unique_async_index.sql"),
+                    "CREATE UNIQUE INDEX ASYNC async_idx_fail_val ON " + idxTable + " (val);\n");
+
+            FluentConfiguration config = Flyway.configure()
+                    .dataSource(jdbcUrl(), user(), null)
+                    .schemas(SCHEMA)
+                    .baselineOnMigrate(true)
+                    .baselineVersion("0")
+                    .locations("filesystem:" + dir.toAbsolutePath());
+            config.getPluginRegister().getPlugin(DSQLConfigurationExtension.class)
+                    .setAwaitAsyncIndexes(true);
+            Flyway flyway = config.load();
+
+            assertThatThrownBy(flyway::migrate).hasMessageContaining("async index build");
+        } finally {
+            try (Connection c = open(); Statement s = c.createStatement()) {
+                c.setAutoCommit(true);
+                s.execute("DROP TABLE IF EXISTS " + idxTable);
+            }
+        }
+    }
+
+    /**
+     * A transactional Java migration that induces a commit-time OCC conflict on its first attempt.
+     * It writes row 1 on Flyway's connection, then — only on attempt 1 — commits a conflicting
+     * write to the same row from a second connection, so Flyway's commit loses the OCC race.
+     */
+    private class ConflictOnFirstAttempt implements JavaMigration {
+        private final AtomicInteger attempts;
+
+        ConflictOnFirstAttempt(AtomicInteger attempts) {
+            this.attempts = attempts;
+        }
+
+        @Override
+        public MigrationVersion getVersion() {
+            return MigrationVersion.fromVersion("1");
+        }
+
+        @Override
+        public String getDescription() {
+            return "occ conflict retry";
+        }
+
+        @Override
+        public Integer getChecksum() {
+            return 1;
+        }
+
+        @Override
+        public boolean canExecuteInTransaction() {
+            return true;
+        }
+
+        @Override
+        public void migrate(Context context) throws Exception {
+            int attempt = attempts.incrementAndGet();
+            try (Statement s = context.getConnection().createStatement()) {
+                s.executeUpdate("UPDATE " + TABLE + " SET val = " + (100 + attempt) + " WHERE id = 1");
+            }
+            if (attempt == 1) {
+                try (Connection connB = open(); Statement s = connB.createStatement()) {
+                    connB.setAutoCommit(false);
+                    s.executeUpdate("UPDATE " + TABLE + " SET val = 999 WHERE id = 1");
+                    connB.commit();
+                }
+            }
+        }
+    }
+
+    private int committedVal() {
+        try (Connection c = open(); Statement s = c.createStatement();
+             ResultSet rs = s.executeQuery("SELECT val FROM " + TABLE + " WHERE id = 1")) {
+            assertThat(rs.next()).isTrue();
+            return rs.getInt(1);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private int successfulRowCount(String version) {
+        try (Connection c = open(); Statement s = c.createStatement();
+             ResultSet rs = s.executeQuery(
+                     "SELECT COUNT(*) FROM " + HISTORY + " WHERE success = true AND version = '" + version + "'")) {
+            assertThat(rs.next()).isTrue();
+            return rs.getInt(1);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private List<String> appliedVersions() {
+        List<String> versions = new ArrayList<>();
+        try (Connection c = open(); Statement s = c.createStatement();
+             ResultSet rs = s.executeQuery(
+                     "SELECT version FROM " + HISTORY + " WHERE success = true ORDER BY installed_rank")) {
+            while (rs.next()) {
+                versions.add(rs.getString(1));
+            }
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        return versions;
+    }
+}

--- a/flyway-database-dsql/src/test/java/org/flywaydb/community/database/dsql/DSQLOccErrorsTest.java
+++ b/flyway-database-dsql/src/test/java/org/flywaydb/community/database/dsql/DSQLOccErrorsTest.java
@@ -1,0 +1,72 @@
+/*-
+ * ========================LICENSE_START=================================
+ * flyway-database-dsql
+ * ========================================================================
+ * Copyright (C) 2010 - 2026 Red Gate Software Ltd
+ * ========================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+package org.flywaydb.community.database.dsql;
+
+import org.junit.jupiter.api.Test;
+
+import java.sql.SQLException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DSQLOccErrorsTest {
+
+    @Test
+    void detectsOccSqlStates() {
+        assertThat(DSQLOccErrors.isOccError(new SQLException("data conflict", "OC000"))).isTrue();
+        assertThat(DSQLOccErrors.isOccError(new SQLException("catalog conflict", "OC001"))).isTrue();
+        assertThat(DSQLOccErrors.isOccError(new SQLException("serialization", "40001"))).isTrue();
+    }
+
+    @Test
+    void detectsOccCodeCarriedInMessage() {
+        // DSQL reports a catalog conflict as SQLSTATE 40001 with the OC code only in the message.
+        assertThat(DSQLOccErrors.isOccError(
+                new SQLException("schema has been updated by another transaction (OC001)", "40001"))).isTrue();
+        assertThat(DSQLOccErrors.isOccError(
+                new SQLException("write conflict (OC000)", "XX000"))).isTrue();
+    }
+
+    @Test
+    void ignoresNonOccSqlStates() {
+        assertThat(DSQLOccErrors.isOccError(new SQLException("syntax error", "42601"))).isFalse();
+        assertThat(DSQLOccErrors.isOccError(new SQLException("no state", (String) null))).isFalse();
+    }
+
+    @Test
+    void detectsOccInCauseChain() {
+        SQLException root = new SQLException("catalog conflict", "OC001");
+        SQLException wrapper = new SQLException("wrapped", "XX000");
+        wrapper.initCause(root);
+        assertThat(DSQLOccErrors.isOccError(wrapper)).isTrue();
+    }
+
+    @Test
+    void detectsOccInNextExceptionChain() {
+        SQLException first = new SQLException("first", "XX000");
+        SQLException next = new SQLException("serialization", "40001");
+        first.setNextException(next);
+        assertThat(DSQLOccErrors.isOccError(first)).isTrue();
+    }
+
+    @Test
+    void nullIsNotOcc() {
+        assertThat(DSQLOccErrors.isOccError(null)).isFalse();
+    }
+}

--- a/flyway-database-dsql/src/test/java/org/flywaydb/community/database/dsql/DSQLOccErrorsTest.java
+++ b/flyway-database-dsql/src/test/java/org/flywaydb/community/database/dsql/DSQLOccErrorsTest.java
@@ -1,0 +1,63 @@
+/*-
+ * ========================LICENSE_START=================================
+ * flyway-database-dsql
+ * ========================================================================
+ * Copyright (C) 2010 - 2026 Red Gate Software Ltd
+ * ========================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+package org.flywaydb.community.database.dsql;
+
+import org.junit.jupiter.api.Test;
+
+import java.sql.SQLException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DSQLOccErrorsTest {
+
+    @Test
+    void detectsOccSqlStates() {
+        assertThat(DSQLOccErrors.isOccError(new SQLException("data conflict", "OC000"))).isTrue();
+        assertThat(DSQLOccErrors.isOccError(new SQLException("catalog conflict", "OC001"))).isTrue();
+        assertThat(DSQLOccErrors.isOccError(new SQLException("serialization", "40001"))).isTrue();
+    }
+
+    @Test
+    void ignoresNonOccSqlStates() {
+        assertThat(DSQLOccErrors.isOccError(new SQLException("syntax error", "42601"))).isFalse();
+        assertThat(DSQLOccErrors.isOccError(new SQLException("no state", (String) null))).isFalse();
+    }
+
+    @Test
+    void detectsOccInCauseChain() {
+        SQLException root = new SQLException("catalog conflict", "OC001");
+        SQLException wrapper = new SQLException("wrapped", "XX000");
+        wrapper.initCause(root);
+        assertThat(DSQLOccErrors.isOccError(wrapper)).isTrue();
+    }
+
+    @Test
+    void detectsOccInNextExceptionChain() {
+        SQLException first = new SQLException("first", "XX000");
+        SQLException next = new SQLException("serialization", "40001");
+        first.setNextException(next);
+        assertThat(DSQLOccErrors.isOccError(first)).isTrue();
+    }
+
+    @Test
+    void nullIsNotOcc() {
+        assertThat(DSQLOccErrors.isOccError(null)).isFalse();
+    }
+}

--- a/flyway-database-dsql/src/test/java/org/flywaydb/community/database/dsql/DSQLParserTest.java
+++ b/flyway-database-dsql/src/test/java/org/flywaydb/community/database/dsql/DSQLParserTest.java
@@ -1,0 +1,39 @@
+/*-
+ * ========================LICENSE_START=================================
+ * flyway-database-dsql
+ * ========================================================================
+ * Copyright (C) 2010 - 2026 Red Gate Software Ltd
+ * ========================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+package org.flywaydb.community.database.dsql;
+
+import org.flywaydb.core.api.configuration.Configuration;
+import org.flywaydb.core.api.configuration.FluentConfiguration;
+import org.flywaydb.core.internal.parser.Parser;
+import org.flywaydb.core.internal.parser.ParsingContext;
+import org.flywaydb.database.postgresql.PostgreSQLParser;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DSQLParserTest {
+
+    @Test
+    void isAPostgresParser() {
+        Configuration config = new FluentConfiguration();
+        Parser parser = new DSQLParser(config, new ParsingContext());
+        assertThat(parser).isInstanceOf(PostgreSQLParser.class);
+    }
+}

--- a/flyway-database-dsql/src/test/java/org/flywaydb/community/database/dsql/DSQLSqlScriptExecutorFactoryTest.java
+++ b/flyway-database-dsql/src/test/java/org/flywaydb/community/database/dsql/DSQLSqlScriptExecutorFactoryTest.java
@@ -1,0 +1,53 @@
+/*-
+ * ========================LICENSE_START=================================
+ * flyway-database-dsql
+ * ========================================================================
+ * Copyright (C) 2010 - 2026 Red Gate Software Ltd
+ * ========================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+package org.flywaydb.community.database.dsql;
+
+import org.flywaydb.core.api.configuration.Configuration;
+import org.flywaydb.core.internal.jdbc.Results;
+import org.flywaydb.core.internal.sqlscript.SqlScript;
+import org.flywaydb.core.internal.sqlscript.SqlScriptExecutor;
+import org.flywaydb.core.internal.sqlscript.SqlScriptExecutorFactory;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.util.List;
+
+import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DSQLSqlScriptExecutorFactoryTest {
+
+    private static final SqlScriptExecutor STUB_EXECUTOR = new SqlScriptExecutor() {
+        @Override public List<Results> execute(SqlScript sqlScript, Configuration configuration) {
+            return emptyList();
+        }
+    };
+
+    @Test
+    void wrapsDelegateExecutorWithDsqlExecutor() {
+        SqlScriptExecutorFactory delegate =
+                (connection, undo, batch, outputQueryResults) -> STUB_EXECUTOR;
+        DSQLSqlScriptExecutorFactory factory = new DSQLSqlScriptExecutorFactory(delegate);
+
+        SqlScriptExecutor executor = factory.createSqlScriptExecutor(null, false, false, false);
+
+        assertThat(executor).isInstanceOf(DSQLSqlScriptExecutor.class);
+    }
+}

--- a/flyway-database-dsql/src/test/java/org/flywaydb/community/database/dsql/DSQLSqlScriptExecutorTest.java
+++ b/flyway-database-dsql/src/test/java/org/flywaydb/community/database/dsql/DSQLSqlScriptExecutorTest.java
@@ -1,0 +1,484 @@
+/*-
+ * ========================LICENSE_START=================================
+ * flyway-database-dsql
+ * ========================================================================
+ * Copyright (C) 2010 - 2026 Red Gate Software Ltd
+ * ========================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+package org.flywaydb.community.database.dsql;
+
+import org.flywaydb.core.api.FlywayException;
+import org.flywaydb.core.api.configuration.Configuration;
+import org.flywaydb.core.api.configuration.FluentConfiguration;
+import org.flywaydb.core.internal.jdbc.Result;
+import org.flywaydb.core.internal.jdbc.Results;
+import org.flywaydb.core.internal.sqlscript.SqlScript;
+import org.flywaydb.core.internal.sqlscript.SqlScriptExecutor;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.sql.CallableStatement;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class DSQLSqlScriptExecutorTest {
+
+    // Records CALL statements prepared on the connection and the bound job id, and simulates the
+    // sys.wait_for_job result: execute() reports a result set whose single boolean column returns
+    // the configured outcome (true = build succeeded, false = build failed). Optionally makes
+    // execute() raise a SQLException instead, to exercise the belt-and-suspenders catch.
+    private static class RecordingConnection {
+        final List<String> preparedCalls = new ArrayList<>();
+        final List<String> boundJobIds = new ArrayList<>();
+        // Starts in a transaction (autoCommit false), like the connection Flyway hands the executor.
+        boolean autoCommit = false;
+        // autoCommit state captured when prepareCall was invoked, so a test can assert the wait
+        // ran outside a transaction block.
+        Boolean autoCommitAtPrepareCall = null;
+        boolean autoCommitRestoredToFalse = false;
+        private final boolean jobSucceeded;
+        private final boolean raiseOnExecute;
+        // Simulate a wait that returns no result set, or one with no row, to exercise fail-closed.
+        private boolean noResultSet = false;
+        private boolean emptyResultSet = false;
+        // Simulate the finally-block restore (setAutoCommit(false)) failing.
+        private boolean raiseOnRestore = false;
+
+        // Defaults to a successful build so existing tests (which only assert the CALL was issued)
+        // keep passing against the success result set.
+        RecordingConnection() {
+            this(true);
+        }
+
+        RecordingConnection(boolean jobSucceeded) {
+            this(jobSucceeded, false);
+        }
+
+        RecordingConnection(boolean jobSucceeded, boolean raiseOnExecute) {
+            this.jobSucceeded = jobSucceeded;
+            this.raiseOnExecute = raiseOnExecute;
+        }
+
+        Connection proxy() {
+            return (Connection) Proxy.newProxyInstance(
+                    getClass().getClassLoader(), new Class<?>[]{Connection.class}, connHandler());
+        }
+
+        private InvocationHandler connHandler() {
+            return (proxy, method, args) -> {
+                switch (method.getName()) {
+                    case "getAutoCommit":
+                        return autoCommit;
+                    case "setAutoCommit":
+                        boolean value = (Boolean) args[0];
+                        if (!value && raiseOnRestore) {
+                            throw new SQLException("simulated setAutoCommit(false) failure");
+                        }
+                        autoCommit = value;
+                        if (!autoCommit) {
+                            autoCommitRestoredToFalse = true;
+                        }
+                        return null;
+                    case "prepareCall":
+                        preparedCalls.add((String) args[0]);
+                        autoCommitAtPrepareCall = autoCommit;
+                        return callableStatementProxy();
+                    default:
+                        return defaultReturn(method);
+                }
+            };
+        }
+
+        private CallableStatement callableStatementProxy() {
+            InvocationHandler h = (proxy, method, args) -> {
+                switch (method.getName()) {
+                    case "setString":
+                        boundJobIds.add((String) args[1]);
+                        return null;
+                    case "execute":
+                        if (raiseOnExecute) {
+                            throw new SQLException("simulated wait_for_job failure");
+                        }
+                        return !noResultSet;   // false = execute() reports no result set
+                    case "getResultSet":
+                        return resultSetProxy();
+                    default:
+                        return defaultReturn(method);
+                }
+            };
+            return (CallableStatement) Proxy.newProxyInstance(
+                    getClass().getClassLoader(), new Class<?>[]{CallableStatement.class}, h);
+        }
+
+        // Single-row result set whose boolean column reports whether the build succeeded.
+        private ResultSet resultSetProxy() {
+            boolean[] advanced = {false};
+            InvocationHandler h = (proxy, method, args) -> {
+                switch (method.getName()) {
+                    case "next":
+                        if (emptyResultSet || advanced[0]) return Boolean.FALSE;
+                        advanced[0] = true;
+                        return Boolean.TRUE;
+                    case "getBoolean":
+                        return jobSucceeded;
+                    default:
+                        return defaultReturn(method);
+                }
+            };
+            return (ResultSet) Proxy.newProxyInstance(
+                    getClass().getClassLoader(), new Class<?>[]{ResultSet.class}, h);
+        }
+
+        private static Object defaultReturn(Method method) {
+            Class<?> r = method.getReturnType();
+            if (r == boolean.class) return Boolean.FALSE;
+            if (r == int.class) return 0;
+            if (r == long.class) return 0L;
+            return null;
+        }
+    }
+
+    private static class FakeDelegate implements SqlScriptExecutor {
+        private final List<Results> toReturn;
+        FakeDelegate(List<Results> toReturn) { this.toReturn = toReturn; }
+        @Override public List<Results> execute(SqlScript sqlScript, Configuration configuration) {
+            return toReturn;
+        }
+    }
+
+    private static Results resultsOf(Result... results) {
+        Results r = new Results();
+        for (Result result : results) {
+            r.addResult(result);
+        }
+        return r;
+    }
+
+    private static Result asyncIndexResult(String jobId, String sql) {
+        return new Result(0L, singletonList("job_id"), singletonList(singletonList(jobId)), sql);
+    }
+
+    private static Result plainResult(long updateCount, String sql) {
+        return new Result(updateCount, emptyList(), emptyList(), sql);
+    }
+
+    // A Configuration whose dsql extension has awaitAsyncIndexes set as given. FluentConfiguration
+    // auto-registers the extension via ServiceLoader, so the wait gate reads the flag from here.
+    private static Configuration configWithAwait(boolean await) {
+        FluentConfiguration c = new FluentConfiguration();
+        c.getPluginRegister().getPlugin(DSQLConfigurationExtension.class).setAwaitAsyncIndexes(await);
+        return c;
+    }
+
+    @Test
+    void waitsForAsyncIndexJob() {
+        RecordingConnection conn = new RecordingConnection();
+        Results results = resultsOf(asyncIndexResult("job-123",
+                "CREATE INDEX ASYNC idx_orders_customer ON orders(customer_id)"));
+        DSQLSqlScriptExecutor executor =
+                new DSQLSqlScriptExecutor(new FakeDelegate(singletonList(results)), conn.proxy());
+
+        executor.execute(null, configWithAwait(true));
+
+        assertThat(conn.preparedCalls).containsExactly("CALL sys.wait_for_job(?)");
+        assertThat(conn.boundJobIds).containsExactly("job-123");
+        // sys.wait_for_job cannot run in a transaction block: the CALL must be issued with
+        // autoCommit on, and the original (in-transaction) state restored afterward.
+        assertThat(conn.autoCommitAtPrepareCall).isTrue();
+        assertThat(conn.autoCommitRestoredToFalse).isTrue();
+        assertThat(conn.autoCommit).isFalse();
+    }
+
+    @Test
+    void doesNotWaitWhenFlagDisabled() {
+        // Async-index result with a job_id, but the opt-in flag is off: no wait fires.
+        RecordingConnection conn = new RecordingConnection();
+        Results results = resultsOf(asyncIndexResult("job-123",
+                "CREATE INDEX ASYNC idx_orders_customer ON orders(customer_id)"));
+        new DSQLSqlScriptExecutor(new FakeDelegate(singletonList(results)), conn.proxy())
+                .execute(null, configWithAwait(false));
+        assertThat(conn.preparedCalls).isEmpty();
+    }
+
+    @Test
+    void doesNotWaitForPlainCreateIndex() {
+        RecordingConnection conn = new RecordingConnection();
+        Results results = resultsOf(plainResult(0L, "CREATE INDEX idx ON orders(customer_id)"));
+        new DSQLSqlScriptExecutor(new FakeDelegate(singletonList(results)), conn.proxy())
+                .execute(null, configWithAwait(true));
+        assertThat(conn.preparedCalls).isEmpty();
+    }
+
+    @Test
+    void doesNotWaitForOrdinaryDml() {
+        RecordingConnection conn = new RecordingConnection();
+        Results results = resultsOf(plainResult(1L, "INSERT INTO orders VALUES (1)"));
+        new DSQLSqlScriptExecutor(new FakeDelegate(singletonList(results)), conn.proxy())
+                .execute(null, configWithAwait(true));
+        assertThat(conn.preparedCalls).isEmpty();
+    }
+
+    @Test
+    void failsMigrationForAsyncIndexWithNoJobId() {
+        // Async-index statement text but no job_id column/value: with awaitAsyncIndexes on, fail
+        // closed rather than silently continuing against a possibly-unbuilt index.
+        RecordingConnection conn = new RecordingConnection();
+        Results results = resultsOf(plainResult(0L, "CREATE INDEX ASYNC idx ON orders(customer_id)"));
+        DSQLSqlScriptExecutor executor =
+                new DSQLSqlScriptExecutor(new FakeDelegate(singletonList(results)), conn.proxy());
+
+        assertThatThrownBy(() -> executor.execute(null, configWithAwait(true)))
+                .isInstanceOf(FlywayException.class);
+        assertThat(conn.preparedCalls).isEmpty();
+    }
+
+    @Test
+    void waitsForAsyncIndexWhenJobIdColumnIsUppercase() {
+        // The job_id column match is case-insensitive; a JOB_ID column must still drive the wait.
+        RecordingConnection conn = new RecordingConnection();
+        Result result = new Result(0L, singletonList("JOB_ID"),
+                singletonList(singletonList("job-uc")),
+                "CREATE INDEX ASYNC idx ON orders(customer_id)");
+        new DSQLSqlScriptExecutor(new FakeDelegate(singletonList(resultsOf(result))), conn.proxy())
+                .execute(null, configWithAwait(true));
+        assertThat(conn.boundJobIds).containsExactly("job-uc");
+    }
+
+    @Test
+    void failsMigrationForAsyncIndexWithoutJobIdColumn() {
+        // Async-index statement whose result has a row but no job_id column: fail closed rather
+        // than silently continuing against a possibly-unbuilt index.
+        RecordingConnection conn = new RecordingConnection();
+        Result result = new Result(0L, singletonList("other"),
+                singletonList(singletonList("val")),
+                "CREATE INDEX ASYNC idx ON orders(customer_id)");
+        DSQLSqlScriptExecutor executor =
+                new DSQLSqlScriptExecutor(new FakeDelegate(singletonList(resultsOf(result))), conn.proxy());
+
+        assertThatThrownBy(() -> executor.execute(null, configWithAwait(true)))
+                .isInstanceOf(FlywayException.class);
+        assertThat(conn.preparedCalls).isEmpty();
+    }
+
+    @Test
+    void waitsForUniqueAsyncIndex() {
+        RecordingConnection conn = new RecordingConnection();
+        Results results = resultsOf(asyncIndexResult("job-u",
+                "CREATE UNIQUE INDEX ASYNC idx ON orders(customer_id)"));
+        new DSQLSqlScriptExecutor(new FakeDelegate(singletonList(results)), conn.proxy())
+                .execute(null, configWithAwait(true));
+        assertThat(conn.boundJobIds).containsExactly("job-u");
+    }
+
+    @Test
+    void waitsForAsyncIndexWithLeadingLineComment() {
+        // Flyway keeps a leading "-- ..." comment in Result.sql(); the wait must still fire.
+        RecordingConnection conn = new RecordingConnection();
+        Results results = resultsOf(asyncIndexResult("job-lc",
+                "-- add lookup index\nCREATE INDEX ASYNC idx ON orders(customer_id)"));
+        new DSQLSqlScriptExecutor(new FakeDelegate(singletonList(results)), conn.proxy())
+                .execute(null, configWithAwait(true));
+        assertThat(conn.boundJobIds).containsExactly("job-lc");
+    }
+
+    @Test
+    void waitsForAsyncIndexWithLeadingBlockComment() {
+        RecordingConnection conn = new RecordingConnection();
+        Results results = resultsOf(asyncIndexResult("job-bc",
+                "/* add lookup index */ CREATE INDEX ASYNC idx ON orders(customer_id)"));
+        new DSQLSqlScriptExecutor(new FakeDelegate(singletonList(results)), conn.proxy())
+                .execute(null, configWithAwait(true));
+        assertThat(conn.boundJobIds).containsExactly("job-bc");
+    }
+
+    @Test
+    void waitsForAsyncIndexWithOverlappingBlockCommentDelimiter() {
+        // "/*/" must be treated as an unterminated opener, not a complete comment: the closer is
+        // searched past the two-char opener so the whole "/*/ ... */" prefix is stripped.
+        RecordingConnection conn = new RecordingConnection();
+        Results results = resultsOf(asyncIndexResult("job-oc",
+                "/*/ note */ CREATE INDEX ASYNC idx ON orders(customer_id)"));
+        new DSQLSqlScriptExecutor(new FakeDelegate(singletonList(results)), conn.proxy())
+                .execute(null, configWithAwait(true));
+        assertThat(conn.boundJobIds).containsExactly("job-oc");
+    }
+
+    @Test
+    void waitsForAsyncIndexWithCommentBetweenKeywords() {
+        // A comment sitting between the keywords must not hide the match.
+        RecordingConnection conn = new RecordingConnection();
+        Results results = resultsOf(asyncIndexResult("job-bk",
+                "CREATE /* c1 */ INDEX /* c2 */ ASYNC idx ON orders(customer_id)"));
+        new DSQLSqlScriptExecutor(new FakeDelegate(singletonList(results)), conn.proxy())
+                .execute(null, configWithAwait(true));
+        assertThat(conn.boundJobIds).containsExactly("job-bk");
+    }
+
+    @Test
+    void waitsForAsyncIndexWithNestedBlockComment() {
+        // A nested block comment must be fully consumed, not truncated at the first "*/".
+        RecordingConnection conn = new RecordingConnection();
+        Results results = resultsOf(asyncIndexResult("job-nc",
+                "/* outer /* inner */ still comment */ CREATE INDEX ASYNC idx ON orders(customer_id)"));
+        new DSQLSqlScriptExecutor(new FakeDelegate(singletonList(results)), conn.proxy())
+                .execute(null, configWithAwait(true));
+        assertThat(conn.boundJobIds).containsExactly("job-nc");
+    }
+
+    @Test
+    void skipsNullResultsEntry() {
+        // Flyway 11.9 adds a null Results when flushing an empty batch around unbatchable DDL; the
+        // decorator must skip it and still wait on the following async-index result.
+        RecordingConnection conn = new RecordingConnection();
+        List<Results> delegateResults = new ArrayList<>();
+        delegateResults.add(null);
+        delegateResults.add(resultsOf(asyncIndexResult("job-nb",
+                "CREATE INDEX ASYNC idx ON orders(customer_id)")));
+        new DSQLSqlScriptExecutor(new FakeDelegate(delegateResults), conn.proxy())
+                .execute(null, configWithAwait(true));
+        assertThat(conn.boundJobIds).containsExactly("job-nb");
+    }
+
+    @Test
+    void waitsOncePerAsyncIndexResultInOrder() {
+        RecordingConnection conn = new RecordingConnection();
+        Results results = resultsOf(
+                asyncIndexResult("job-1", "CREATE INDEX ASYNC a ON t(x)"),
+                plainResult(0L, "CREATE INDEX b ON t(y)"),
+                asyncIndexResult("job-2", "CREATE INDEX ASYNC c ON t(z)"));
+        new DSQLSqlScriptExecutor(new FakeDelegate(singletonList(results)), conn.proxy())
+                .execute(null, configWithAwait(true));
+        assertThat(conn.boundJobIds).containsExactly("job-1", "job-2");
+    }
+
+    @Test
+    void passesDelegateResultsThroughUnchanged() {
+        RecordingConnection conn = new RecordingConnection();
+        List<Results> delegateResults = singletonList(resultsOf(plainResult(0L, "SELECT 1")));
+        List<Results> returned =
+                new DSQLSqlScriptExecutor(new FakeDelegate(delegateResults), conn.proxy())
+                        .execute(null, configWithAwait(true));
+        assertThat(returned).isSameAs(delegateResults);
+    }
+
+    @Test
+    void failsMigrationWhenAsyncIndexBuildReturnsFalse() {
+        // A failed build does not raise: sys.wait_for_job returns a single boolean 'false'. The
+        // wait must still be issued, and the migration must fail explicitly on the false result.
+        RecordingConnection conn = new RecordingConnection(false);
+        Results results = resultsOf(asyncIndexResult("job-fail",
+                "CREATE INDEX ASYNC idx_orders_customer ON orders(customer_id)"));
+        DSQLSqlScriptExecutor executor =
+                new DSQLSqlScriptExecutor(new FakeDelegate(singletonList(results)), conn.proxy());
+
+        assertThatThrownBy(() -> executor.execute(null, configWithAwait(true)))
+                .isInstanceOf(FlywayException.class);
+        assertThat(conn.preparedCalls).containsExactly("CALL sys.wait_for_job(?)");
+        assertThat(conn.boundJobIds).containsExactly("job-fail");
+        // autoCommit must be restored even when the migration fails (the restore is in finally).
+        assertThat(conn.autoCommitRestoredToFalse).isTrue();
+        assertThat(conn.autoCommit).isFalse();
+    }
+
+    @Test
+    void failsMigrationWhenWaitRaisesSqlException() {
+        // Belt-and-suspenders: if sys.wait_for_job raises instead, it still fails the migration.
+        RecordingConnection conn = new RecordingConnection(true, true);
+        Results results = resultsOf(asyncIndexResult("job-raise",
+                "CREATE INDEX ASYNC idx_orders_customer ON orders(customer_id)"));
+        DSQLSqlScriptExecutor executor =
+                new DSQLSqlScriptExecutor(new FakeDelegate(singletonList(results)), conn.proxy());
+
+        assertThatThrownBy(() -> executor.execute(null, configWithAwait(true)))
+                .isInstanceOf(FlywayException.class);
+        assertThat(conn.preparedCalls).containsExactly("CALL sys.wait_for_job(?)");
+        // autoCommit must be restored even when the wait raises (the restore is in finally).
+        assertThat(conn.autoCommitRestoredToFalse).isTrue();
+        assertThat(conn.autoCommit).isFalse();
+    }
+
+    @Test
+    void failsMigrationWhenAutoCommitRestoreFailsAfterSuccessfulWait() {
+        // Body succeeds but the finally restore throws: must not be swallowed (a leaked
+        // autoCommit=true would silently defeat rollback for the rest of the run).
+        RecordingConnection conn = new RecordingConnection();
+        conn.raiseOnRestore = true;
+        Results results = resultsOf(asyncIndexResult("job-restore",
+                "CREATE INDEX ASYNC idx ON orders(customer_id)"));
+        DSQLSqlScriptExecutor executor =
+                new DSQLSqlScriptExecutor(new FakeDelegate(singletonList(results)), conn.proxy());
+
+        assertThatThrownBy(() -> executor.execute(null, configWithAwait(true)))
+                .isInstanceOf(FlywayException.class)
+                .hasMessageContaining("restore autoCommit");
+    }
+
+    @Test
+    void keepsPrimaryFailureWhenAutoCommitRestoreAlsoFails() {
+        // Body fails (build did not succeed) AND the restore throws: the build failure stays the
+        // primary error, with the restore failure attached as suppressed.
+        RecordingConnection conn = new RecordingConnection(false);
+        conn.raiseOnRestore = true;
+        Results results = resultsOf(asyncIndexResult("job-both",
+                "CREATE INDEX ASYNC idx ON orders(customer_id)"));
+        DSQLSqlScriptExecutor executor =
+                new DSQLSqlScriptExecutor(new FakeDelegate(singletonList(results)), conn.proxy());
+
+        assertThatThrownBy(() -> executor.execute(null, configWithAwait(true)))
+                .isInstanceOf(FlywayException.class)
+                .hasMessageContaining("did not succeed")
+                .satisfies(t -> assertThat(t.getSuppressed()).isNotEmpty());
+    }
+
+    @Test
+    void failsMigrationWhenWaitReturnsNoResultSet() {
+        // execute() reporting no result set is not a success confirmation: fail closed.
+        RecordingConnection conn = new RecordingConnection();
+        conn.noResultSet = true;
+        Results results = resultsOf(asyncIndexResult("job-nrs",
+                "CREATE INDEX ASYNC idx ON orders(customer_id)"));
+        DSQLSqlScriptExecutor executor =
+                new DSQLSqlScriptExecutor(new FakeDelegate(singletonList(results)), conn.proxy());
+
+        assertThatThrownBy(() -> executor.execute(null, configWithAwait(true)))
+                .isInstanceOf(FlywayException.class);
+        assertThat(conn.autoCommitRestoredToFalse).isTrue();
+    }
+
+    @Test
+    void failsMigrationWhenWaitReturnsEmptyResultSet() {
+        // A result set with no row is not a success confirmation either: fail closed.
+        RecordingConnection conn = new RecordingConnection();
+        conn.emptyResultSet = true;
+        Results results = resultsOf(asyncIndexResult("job-ers",
+                "CREATE INDEX ASYNC idx ON orders(customer_id)"));
+        DSQLSqlScriptExecutor executor =
+                new DSQLSqlScriptExecutor(new FakeDelegate(singletonList(results)), conn.proxy());
+
+        assertThatThrownBy(() -> executor.execute(null, configWithAwait(true)))
+                .isInstanceOf(FlywayException.class);
+        assertThat(conn.autoCommitRestoredToFalse).isTrue();
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,7 @@
         <module>flyway-database-timeplus</module>
         <module>flyway-database-questdb</module>
         <module>flyway-database-iris</module>
+        <module>flyway-database-dsql</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
## Summary

Adds `flyway-database-dsql`, a community module for [Amazon Aurora DSQL](https://docs.aws.amazon.com/aurora-dsql/).

DSQL is PostgreSQL wire-compatible but a distinct distributed engine, so Flyway resolves it to the PostgreSQL type and fails on the first migration (`ERROR: setting configuration parameter "role" not supported`). This module gives it its own database type, mirroring `flyway-database-yugabytedb`.

It upstreams the plugin AWS already ships on Maven Central (`software.amazon.dsql:aurora-dsql-flyway-support`), as discussed and confirmed in flyway/flyway#4263. The code has been through several rounds of internal AWS review.

## DSQL adaptations

- **One DDL per transaction** — DSQL disallows mixing DDL and DML, so each schema change runs in its own transaction.
- **IAM authentication** — role-based access via IAM, replacing PostgreSQL's `SET ROLE`.
- **Optimistic concurrency control** — DSQL surfaces `OC000` / `OC001` / `40001` conflicts at commit time instead of using advisory locks. The module retries the migration transaction on conflict, configurable via `flyway.dsql.occMaxRetries` / `occMaxRetryDelaySeconds`.
- **Async indexes** — DSQL has no synchronous index build, so `CREATE INDEX ASYNC` returns before the index is ready. An opt-in `flyway.dsql.awaitAsyncIndexes` blocks the migration on the build via `sys.wait_for_job`, so a failed build fails the deploy.

## Module layout

Follows the community-module contract: registered in the root `pom.xml`, package `org.flywaydb.community.database.dsql`, `DSQLDatabaseType` implementing `CommunityDatabaseType`, and the `META-INF/services` Plugin registration. The Aurora DSQL JDBC connector is not bundled; users supply it on the runtime classpath (documented in the module README).

## Test coverage

- Unit tests covering OCC classification and retry, the configuration extension, database type resolution, the parser, and the async-index executor — all run in CI.
- `DSQLIntegrationTest` — an end-to-end test against a live cluster, gated on `DSQL_CLUSTER_ENDPOINT` and skipped in CI (DSQL has no local or Testcontainers equivalent). It exercises the OCC retry and the async-index wait/failure paths.

Addresses flyway/flyway#4263.