### PR TITLE
fix(test): exercise QuestDB rename on a dedicated table

### DIFF
--- a/flyway-database-questdb/src/test/java/org/flywaydb/community/database/questdb/QuestDBTest.java
+++ b/flyway-database-questdb/src/test/java/org/flywaydb/community/database/questdb/QuestDBTest.java
@@ -71,11 +71,9 @@ public class QuestDBTest {
     public void testMigration3_RenameTable() throws SQLException {
         assertMigration(
                 "3",
-                "trades_table",
-                "instrument\tside\tqty\tprice\tts\n" +
-                "SYM1\tBUY\t100.0\t12.56\t2025-05-09 00:01:00.000000\n" +
-                "SYM2\tBUY\t120.0\t10.11\t2025-05-09 00:02:00.000000\n" +
-                "SYM1\tSELL\t50.0\t12.44\t2025-05-09 00:03:00.000000\n"
+                "rename_target",
+                "instrument\tts\n" +
+                "SYM1\t2025-05-09 00:01:00.000000\n"
         );
     }
 
@@ -131,11 +129,14 @@ public class QuestDBTest {
 
     @Test
     public void testMigration7_DropTable() throws SQLException {
+        // rename_target must still be present: it proves dropping trades did not resurrect a
+        // table under an earlier name via a stale table token. See V3__Rename_table.sql.
         assertMigration(
                 "7",
                 "select table_name, designatedTimestamp, partitionBy,walEnabled from tables()",
                 "table_name\tdesignatedTimestamp\tpartitionBy\twalEnabled\n" +
-                        "flyway_schema_history\tinstalled_on\tDAY\tt\n"
+                        "flyway_schema_history\tinstalled_on\tDAY\tt\n" +
+                        "rename_target\tts\tDAY\tt\n"
         );
     }
 

--- a/flyway-database-questdb/src/test/resources/questdb_migration/V3__Rename_table.sql
+++ b/flyway-database-questdb/src/test/resources/questdb_migration/V3__Rename_table.sql
@@ -17,4 +17,14 @@
 -- limitations under the License.
 -- =========================LICENSE_END==================================
 ---
-RENAME TABLE trades TO trades_table;
+-- The rename is exercised on its own table so that `trades` is never renamed. QuestDB's
+-- asynchronous column conversion can complete after a DROP holding an earlier table name,
+-- which re-registers the dropped table under that name and leaves a phantom behind.
+CREATE TABLE rename_source (
+    instrument SYMBOL,
+    ts TIMESTAMP
+) TIMESTAMP(ts) PARTITION BY DAY WAL;
+
+INSERT INTO rename_source (instrument, ts) values ('SYM1', '2025-05-09T00:01:00.000000Z');
+
+RENAME TABLE rename_source TO rename_target;

--- a/flyway-database-questdb/src/test/resources/questdb_migration/V4__Add_venue_column.sql
+++ b/flyway-database-questdb/src/test/resources/questdb_migration/V4__Add_venue_column.sql
@@ -17,6 +17,4 @@
 -- limitations under the License.
 -- =========================LICENSE_END==================================
 ---
-RENAME TABLE trades_table TO trades;
-
 ALTER TABLE trades ADD COLUMN venue VARCHAR;

--- a/flyway-database-questdb/src/test/resources/questdb_migration/V7__Drop_trades_table.sql
+++ b/flyway-database-questdb/src/test/resources/questdb_migration/V7__Drop_trades_table.sql
@@ -17,4 +17,5 @@
 -- limitations under the License.
 -- =========================LICENSE_END==================================
 ---
+-- See V3 for why `trades` is never renamed before this drop.
 DROP TABLE trades;


### PR DESCRIPTION
## What

The QuestDB test fixture no longer renames its `trades` table. The rename is exercised on a dedicated `rename_source` -> `rename_target` pair instead, so `trades` keeps one name for its whole life.

Test-only, no shipped code.

## Why

`QuestDBTest.testMigration7_DropTable` fails consistently on `main`, which fails the reactor at module 12 of 14 and skips every publish step with it.

The cause is in QuestDB rather than the fixture. `V5`'s `ALTER COLUMN venue TYPE SYMBOL` converts asynchronously, and that job holds a table token captured before `V4` renamed the table back to `trades`. Completing *after* `V7`'s `DROP TABLE`, it re-registers the just-dropped directory under the stale name and leaves a phantom `trades_table` row:

```
ConvertOperatorImpl completed column conversion [at=TableToken{tableName=trades_table, dirName=trades~9}, column=venue]
```

The equivalent line in the last passing run reads `at=trades~9`, with no stale name. Removing the earlier name removes what the resurrection depends on.

`rename_target` is deliberately not dropped - that would reintroduce the rename-then-drop pattern being removed, and its presence now doubles as the regression check.

Reported upstream as questdb/questdb#7565. Looks like the same family as questdb/questdb#4011 and questdb/questdb#5963.

## Verification

`QuestDBTest` cannot run locally, as Testcontainers cannot reach the local Docker daemon. Real Flyway was driven at `questdb/questdb:9.3.5` for targets 1-7 instead, comparing the exact result strings against the assertions: 1, 2, 3, 4, 6 and 7 matched byte-for-byte, and 5 was sampled mid-conversion so shows the pre-conversion type. CI is green across all 14 modules, with `QuestDBTest` 7/7 in 23.8s against 94s for the failure.

The failure is timing-dependent and a byte-identical tree passed seven hours before it started failing, so one green run is not proof. The argument is mechanical: the stale name can no longer exist.
